### PR TITLE
게시글 이미지 업로드 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'org.jsoup:jsoup:1.16.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/popping/PoppingApplication.java
+++ b/src/main/java/com/example/popping/PoppingApplication.java
@@ -3,8 +3,10 @@ package com.example.popping;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class PoppingApplication {
 

--- a/src/main/java/com/example/popping/config/S3Config.java
+++ b/src/main/java/com/example/popping/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.example.popping.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/example/popping/controller/BoardController.java
+++ b/src/main/java/com/example/popping/controller/BoardController.java
@@ -3,7 +3,6 @@ package com.example.popping.controller;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -11,8 +10,6 @@ import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import com.example.popping.constant.SessionConst;
-import com.example.popping.domain.User;
 import com.example.popping.domain.UserPrincipal;
 import com.example.popping.dto.BoardCreateRequest;
 import com.example.popping.dto.BoardResponse;
@@ -39,7 +36,7 @@ public class BoardController {
 
     @GetMapping("/{slug}")
     public String getBoard(@PathVariable String slug, Model model) {
-        BoardResponse boardResponse = boardService.getBoard(slug);
+        BoardResponse boardResponse = boardService.getBoardResponse(slug);
         List<PostResponse> postResponses = postService.getPostsByBoardSlug(slug);
         model.addAttribute("board", boardResponse);
         model.addAttribute("posts", postResponses);

--- a/src/main/java/com/example/popping/controller/ImageController.java
+++ b/src/main/java/com/example/popping/controller/ImageController.java
@@ -1,0 +1,27 @@
+package com.example.popping.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+import lombok.RequiredArgsConstructor;
+
+import com.example.popping.dto.ImageResponse;
+import com.example.popping.service.ImageService;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping("/upload")
+    @ResponseBody
+    public ImageResponse uploadImage(@RequestParam("image") MultipartFile file) {
+        return imageService.uploadAndCreateTempImage(file);
+    }
+}

--- a/src/main/java/com/example/popping/controller/PostController.java
+++ b/src/main/java/com/example/popping/controller/PostController.java
@@ -11,8 +11,6 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import com.example.popping.constant.SessionConst;
-import com.example.popping.domain.User;
 import com.example.popping.domain.UserPrincipal;
 import com.example.popping.dto.*;
 import com.example.popping.service.CommentService;
@@ -29,8 +27,7 @@ public class PostController {
     @GetMapping("/{postId}")
     public String getPost(@PathVariable String slug, @PathVariable Long postId,
                           Model model) {
-        System.out.println(postId);
-        PostResponse postResponse = postService.getPost(postId);
+        PostResponse postResponse = postService.getPostResponse(postId);
         List<CommentResponse> commentResponses = commentService.getCommentsByPostId(postId);
         model.addAttribute("post", postResponse);
         model.addAttribute("comments", commentResponses);
@@ -128,7 +125,7 @@ public class PostController {
         if (verified == null || !verified) {
             return "redirect:/boards/" + slug + "/" + postId + "/edit-password";
         }
-        PostResponse dto = postService.getPost(postId);
+        PostResponse dto = postService.getPostResponse(postId);
         model.addAttribute("form", dto);
         model.addAttribute("slug", slug);
         return "post/edit-form";
@@ -159,7 +156,7 @@ public class PostController {
                                     Model model,
                                     HttpSession session) {
         if(bindingResult.hasErrors()){
-            PostResponse postResponse = postService.getPost(postId);
+            PostResponse postResponse = postService.getPostResponse(postId);
             model.addAttribute("form", postResponse);
             model.addAttribute("slug", slug);
             return "post/edit-form";

--- a/src/main/java/com/example/popping/domain/Image.java
+++ b/src/main/java/com/example/popping/domain/Image.java
@@ -1,0 +1,37 @@
+package com.example.popping.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Image extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private ImageStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    public void updatePostAndStatus(Post post) {
+        this.post = post;
+        this.status = ImageStatus.PERMANENT;
+    }
+
+    @Builder
+    public Image(String imageUrl) {
+        this.imageUrl = imageUrl;
+        this.status = ImageStatus.TEMP;
+    }
+}

--- a/src/main/java/com/example/popping/domain/ImageStatus.java
+++ b/src/main/java/com/example/popping/domain/ImageStatus.java
@@ -1,0 +1,5 @@
+package com.example.popping.domain;
+
+public enum ImageStatus {
+    TEMP, PERMANENT
+}

--- a/src/main/java/com/example/popping/domain/Post.java
+++ b/src/main/java/com/example/popping/domain/Post.java
@@ -17,6 +17,8 @@ public class Post extends BaseEntity {
     private Long id;
 
     private String title;
+
+    @Lob
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/popping/dto/ImageResponse.java
+++ b/src/main/java/com/example/popping/dto/ImageResponse.java
@@ -1,0 +1,16 @@
+package com.example.popping.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ImageResponse {
+    private String imageUrl;
+
+    public static ImageResponse from(String imageUrl) {
+        return ImageResponse.builder()
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/example/popping/exception/CustomAppException.java
+++ b/src/main/java/com/example/popping/exception/CustomAppException.java
@@ -1,0 +1,21 @@
+package com.example.popping.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomAppException extends RuntimeException {
+    private final ErrorType errorType;
+    private final String customMessage;
+
+    public CustomAppException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.customMessage = null;
+    }
+
+    public CustomAppException(ErrorType errorType, String customMessage) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.customMessage = customMessage;
+    }
+}

--- a/src/main/java/com/example/popping/exception/ErrorType.java
+++ b/src/main/java/com/example/popping/exception/ErrorType.java
@@ -1,0 +1,43 @@
+package com.example.popping.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorType {
+    //400
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청값이 올바르지 않습니다."),
+    //401
+    NO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    //403
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    //404
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USERNAME_DUPLICATED(HttpStatus.NOT_FOUND, "이미 사용중인 아이디입니다."),
+    NICKNAME_DUPLICATED(HttpStatus.NOT_FOUND, "이미 사용중인 닉네임입니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시판을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    EMPTY_IMAGE_FILE(HttpStatus.NOT_FOUND, "이미지 파일이 비어있습니다."),
+    NO_FILE_EXTENTION(HttpStatus.NOT_FOUND, "파일 확장자가 없습니다. 올바른 이미지 파일을 업로드해주세요."),
+    INVALID_FILE_EXTENTION(HttpStatus.NOT_FOUND, "올바른 이미지 파일이 아닙니다. 지원하는 확장자는 jpg, jpeg, png입니다."),
+
+
+    //500
+    IO_EXCEPTION_ON_IMAGE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 IO 예외가 발생했습니다."),
+    PUT_OBJECT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "S3에 이미지를 업로드하는 중 문제가 발생했습니다."),
+    IO_EXCEPTION_ON_IMAGE_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제 중 IO 예외가 발생했습니다."),
+    TEMP_IMAGE_DELETE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "임시 이미지 삭제 중 문제가 발생했습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시만 기달려주세요.");
+
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    public int getStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/example/popping/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/popping/exception/GlobalExceptionHandler.java
@@ -1,15 +1,20 @@
 package com.example.popping.exception;
 
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(AccessDeniedException.class)
-    public String handleAccessDenied(AccessDeniedException ex, Model model) {
-        model.addAttribute("errorMessage", ex.getMessage());
-        return "error/403";
+
+    @ExceptionHandler(CustomAppException.class)
+    public String handleCustomAppException(Model model, CustomAppException e) {
+        log.error("CustomAppException: {}", e.getMessage());
+        model.addAttribute("errorCode", e.getErrorType().name());
+        model.addAttribute("message",
+                (e.getCustomMessage() != null) ? e.getCustomMessage() : e.getErrorType().getMessage());
+        return "error/custom-error";
     }
 }

--- a/src/main/java/com/example/popping/repository/ImageRepository.java
+++ b/src/main/java/com/example/popping/repository/ImageRepository.java
@@ -1,0 +1,17 @@
+package com.example.popping.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.popping.domain.Image;
+import com.example.popping.domain.ImageStatus;
+import com.example.popping.domain.Post;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    List<Image> findAllByPost(Post post);
+
+    List<Image> findAllByImageUrlIn(List<String> imageUrls);
+
+    List<Image> findAllByStatus(ImageStatus imageStatus);
+}

--- a/src/main/java/com/example/popping/scheduler/TempImageCleanupScheduler.java
+++ b/src/main/java/com/example/popping/scheduler/TempImageCleanupScheduler.java
@@ -1,0 +1,22 @@
+package com.example.popping.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.example.popping.service.ImageService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TempImageCleanupScheduler {
+
+    private final ImageService imageService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runCleanupTask() {
+        imageService.cleanUpUnusedTempImages();
+        log.info("Temporary image cleanup task executed successfully.");
+    }
+}

--- a/src/main/java/com/example/popping/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/popping/service/CustomUserDetailsService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 
 import com.example.popping.domain.User;
 import com.example.popping.domain.UserPrincipal;
+import com.example.popping.exception.CustomAppException;
+import com.example.popping.exception.ErrorType;
 import com.example.popping.repository.UserRepository;
 
 @Service
@@ -19,7 +21,8 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + loginId));
+                .orElseThrow(() -> new CustomAppException(ErrorType.USER_NOT_FOUND,
+                        "사용자를 찾을 수 없습니다: " + loginId));
         return new UserPrincipal(user);
     }
 }

--- a/src/main/java/com/example/popping/service/ImageService.java
+++ b/src/main/java/com/example/popping/service/ImageService.java
@@ -1,0 +1,185 @@
+package com.example.popping.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.example.popping.domain.Image;
+import com.example.popping.domain.ImageStatus;
+import com.example.popping.domain.Post;
+import com.example.popping.dto.ImageResponse;
+import com.example.popping.exception.CustomAppException;
+import com.example.popping.exception.ErrorType;
+import com.example.popping.repository.ImageRepository;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.*;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ImageService {
+
+    private final AmazonS3 amazonS3;
+    private final ImageRepository imageRepository;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    @Transactional
+    public ImageResponse uploadAndCreateTempImage(MultipartFile multipartFile) {
+        Image image = Image.builder()
+                .imageUrl(upload(multipartFile))
+                .build();
+
+        imageRepository.save(image);
+
+        return ImageResponse.from(image.getImageUrl());
+    }
+
+    public String upload(MultipartFile image) {
+        if(image.isEmpty() || Objects.isNull(image.getOriginalFilename())){
+            throw new CustomAppException(ErrorType.EMPTY_IMAGE_FILE);
+        }
+        return this.uploadImage(image);
+    }
+
+    private String uploadImage(MultipartFile image) {
+        this.validateImageFileExtention(image.getOriginalFilename());
+        try {
+            return this.uploadImageToS3(image);
+        } catch (IOException e) {
+            throw new CustomAppException(ErrorType.IO_EXCEPTION_ON_IMAGE_UPLOAD);
+        }
+    }
+
+    private void validateImageFileExtention(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new CustomAppException(ErrorType.NO_FILE_EXTENTION,
+                    "파일 확장자가 없습니다. 올바른 이미지 파일을 업로드해주세요.");
+        }
+
+        String extention = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+        if (!allowedExtentionList.contains(extention)) {
+            throw new CustomAppException(ErrorType.INVALID_FILE_EXTENTION,
+                    "지원하는 이미지 파일 확장자는 " + String.join(", ", allowedExtentionList) + "입니다.");
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        String originalFilename = image.getOriginalFilename();
+        String extention = originalFilename.substring(originalFilename.lastIndexOf("."));
+
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;
+
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extention);
+        metadata.setContentLength(bytes.length);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try{
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(putObjectRequest);
+        }catch (Exception e){
+            throw new CustomAppException(ErrorType.PUT_OBJECT_EXCEPTION,
+                    "S3에 이미지를 업로드하는 중 문제가 발생했습니다: " + originalFilename);
+        }finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+
+        return amazonS3.getUrl(bucketName, s3FileName).toString();
+    }
+
+    @Transactional
+    public void deleteImages(Post post) {
+        List<Image> images = imageRepository.findAllByPost(post);
+        if (!images.isEmpty()) {
+            images.forEach(image -> deleteImageFromS3(image.getImageUrl()));
+            imageRepository.deleteAll(images);
+        }
+    }
+
+    public void deleteImageFromS3(String imageAddress){
+        String key = getKeyFromImageAddress(imageAddress);
+        try{
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        }catch (Exception e){
+            throw new CustomAppException(ErrorType.IO_EXCEPTION_ON_IMAGE_DELETE,
+                    "이미지 삭제 중 문제가 발생했습니다: " + imageAddress);
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress){
+        try{
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1);
+        }catch (MalformedURLException | UnsupportedEncodingException e){
+            throw new CustomAppException(ErrorType.IO_EXCEPTION_ON_IMAGE_DELETE,
+                    "이미지 주소가 잘못되었습니다: " + imageAddress);
+        }
+    }
+
+    public void linkToPostAndMakePermanent(String content, Post post) {
+        List<String> imageUrls = extractImageUrls(content);
+
+        List<Image> images = imageRepository.findAllByImageUrlIn(imageUrls);
+
+        for (Image image : images) {
+            image.updatePostAndStatus(post);
+        }
+    }
+
+    public List<String> extractImageUrls(String htmlContent) {
+        List<String> imageUrls = new ArrayList<>();
+        Document doc = Jsoup.parse(htmlContent);
+
+        Elements imgTags = doc.select("img");
+        for (Element img : imgTags) {
+            String src = img.attr("src");
+            imageUrls.add(src);
+        }
+        return imageUrls;
+    }
+
+    public void cleanUpUnusedTempImages() {
+        List<Image> tempImages = imageRepository.findAllByStatus(ImageStatus.TEMP);
+        for (Image image : tempImages) {
+            try {
+                deleteImageFromS3(image.getImageUrl());
+                imageRepository.delete(image);
+            } catch (Exception e) {
+                throw new CustomAppException(ErrorType.TEMP_IMAGE_DELETE_EXCEPTION,
+                        "임시 이미지 삭제 중 문제가 발생했습니다: " + image.getImageUrl());
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/popping/service/PostService.java
+++ b/src/main/java/com/example/popping/service/PostService.java
@@ -6,15 +6,12 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
-import com.example.popping.domain.Board;
-import com.example.popping.domain.Post;
-import com.example.popping.domain.User;
-import com.example.popping.domain.UserPrincipal;
+import com.example.popping.domain.*;
 import com.example.popping.dto.*;
-import com.example.popping.repository.BoardRepository;
+import com.example.popping.exception.CustomAppException;
+import com.example.popping.exception.ErrorType;
 import com.example.popping.repository.PostRepository;
 
 @Service
@@ -22,80 +19,86 @@ import com.example.popping.repository.PostRepository;
 @RequiredArgsConstructor
 public class PostService {
 
-    private final PostRepository postRepository;
-    private final BoardRepository boardRepository;
+    private final BoardService boardService;
+    private final ImageService imageService;
     private final PasswordEncoder passwordEncoder;
+    private final PostRepository postRepository;
 
     public Long createMemberPost(String slug, MemberPostCreateRequest dto, UserPrincipal user) {
-        Board board = boardRepository.findBySlug(slug)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시판이 존재하지 않습니다."));
+        Board board = boardService.getBoard(slug);
 
         Post post = dto.toEntity(user.getUser(), board);
         postRepository.save(post);
+
+        imageService.linkToPostAndMakePermanent(dto.getContent(), post);
 
         return post.getId();
     }
 
     public Long createGuestPost(String slug, GuestPostCreateRequest dto) {
-        Board board = boardRepository.findBySlug(slug)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시판이 존재하지 않습니다."));
+        Board board = boardService.getBoard(slug);
 
         Post post = dto.toEntity(board, passwordEncoder.encode(dto.getGuestPassword()));
         postRepository.save(post);
+
+        imageService.linkToPostAndMakePermanent(dto.getContent(), post);
 
         return post.getId();
     }
 
     public void updatePost(Long postId, MemberPostUpdateRequest dto, UserPrincipal user) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글이 존재하지 않습니다."));
+        Post post = getPost(postId);
 
         validateAuthor(post, user.getUser());
 
         post.memberUpdate(dto.getTitle(), dto.getContent());
+
+        imageService.linkToPostAndMakePermanent(dto.getContent(), post);
     }
 
     public void updatePostAsGuest(Long postId, GuestPostUpdateRequest dto) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글이 존재하지 않습니다."));
+        Post post = getPost(postId);
 
         post.guestUpdate(dto.getTitle(), dto.getContent(), dto.getGuestNickname(), passwordEncoder.encode(dto.getGuestPassword()));
+
+        imageService.linkToPostAndMakePermanent(dto.getContent(), post);
     }
 
     public void deletePost(Long postId, UserPrincipal user) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글이 존재하지 않습니다."));
+        Post post = getPost(postId);
 
         validateAuthor(post, user.getUser());
+
+        imageService.deleteImages(post);
 
         postRepository.delete(post);
     }
 
     public void deletePostAsGuest(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글이 존재하지 않습니다."));
+        Post post = getPost(postId);
+
+        imageService.deleteImages(post);
 
         postRepository.delete(post);
     }
 
     @Transactional(readOnly = true)
-    public PostResponse getPost(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글이 존재하지 않습니다."));
+    public PostResponse getPostResponse(Long postId) {
+        Post post = getPost(postId);
 
         return PostResponse.from(post);
     }
 
     @Transactional(readOnly = true)
-    public Post getPostEntity(Long postId) {
+    public Post getPost(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomAppException(ErrorType.POST_NOT_FOUND,
+                        "해당 게시글이 존재하지 않습니다: " + postId));
     }
 
     @Transactional(readOnly = true)
     public PostResponse getMemberPostForEdit(Long postId, UserPrincipal user) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시글이 존재하지 않습니다."));
+        Post post = getPost(postId);
 
         validateAuthor(post, user.getUser());
 
@@ -103,17 +106,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponse> getAllPosts() {
-        return postRepository.findAll()
-                .stream()
-                .map(PostResponse::from)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
     public List<PostResponse> getPostsByBoardSlug(String slug) {
-        Board board = boardRepository.findBySlug(slug)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시판이 존재하지 않습니다."));
+        Board board = boardService.getBoard(slug);
 
         List<Post> posts = postRepository.findAllByBoard(board);
 
@@ -124,16 +118,17 @@ public class PostService {
 
     private void validateAuthor(Post post, User user) {
         if (!post.isAuthor(user)) {
-            throw new AccessDeniedException("작성자가 아닙니다.");
+            throw new CustomAppException(ErrorType.ACCESS_DENIED,
+                    "작성자가 아닙니다: " + user.getLoginId());
         }
     }
 
     public boolean verifyGuestPassword(Long postId, String password) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다."));
+        Post post = getPost(postId);
 
         if (post.getAuthor() != null) {
-            throw new AccessDeniedException("회원 게시글입니다.");
+            throw new CustomAppException(ErrorType.ACCESS_DENIED,
+                    "회원 게시글은 비밀번호로 삭제할 수 없습니다.");
         }
 
         return passwordEncoder.matches(password, post.getGuestPasswordHash());

--- a/src/main/java/com/example/popping/service/UserService.java
+++ b/src/main/java/com/example/popping/service/UserService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import com.example.popping.domain.User;
 import com.example.popping.dto.JoinRequest;
 import com.example.popping.dto.LoginRequest;
+import com.example.popping.exception.CustomAppException;
+import com.example.popping.exception.ErrorType;
 import com.example.popping.repository.UserRepository;
 
 @Service
@@ -36,18 +38,9 @@ public class UserService {
     public User getLoginUserById(Long userId) {
         if (userId == null) {
             return null;
-        }
-
-        Optional<User> optionalUser = userRepository.findById(userId);
-        return optionalUser.orElse(null);
-    }
-
-    public User getLoginUserByLoginId(String loginId) {
-        if (loginId == null) {
-            return null;
-        }
-
-        Optional<User> optionalUser = userRepository.findByLoginId(loginId);
-        return optionalUser.orElse(null);
+        };
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomAppException(ErrorType.USER_NOT_FOUND,
+                        "사용자를 찾을 수 없습니다: " + userId));
     }
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #47 


## :bulb: 상세 내용:

### ✅ 이미지 업로드 및 저장
- [x] AWS S3 버킷 설정 및 권한 구성
- [x] `/images/upload` API 엔드포인트 구현 (비동기 이미지 업로드 처리)
- [x] Toast UI Editor 내 `addImageBlobHook`을 통해 비동기 업로드 연동
- [x] 업로드된 이미지는 `Image` 엔티티로 저장 (초기 상태: `TEMP`)
- [x] HTML 본문에서 `<img>` 태그 파싱하여 해당 이미지와 게시글 연결 후 `PERMANENT` 상태로 전환

### ✅ 이미지 렌더링 및 본문 저장
- [x] 게시글 작성 시 HTML 본문 저장 및 렌더링
- [x] 미리보기에서 본문 내 이미지 정상 출력 확인

### ✅ 게시글 작성 프로세스 개선
- [x] 이미지 업로드 시점에 DB에는 `TEMP` 상태로 저장
- [x] 게시글 저장 시 `ImageService` 통해 관련 이미지만 `PERMANENT`로 전환
- [x] 사용자가 업로드만 하고 게시글을 저장하지 않을 경우 cleanup 대상이 됨

### ✅ 임시 이미지 정리 기능
- [x] `@Scheduled` 애노테이션으로 매일 00:00에 TEMP + post == null + 생성된 지 1일 이상 된 이미지 정리
- [x] S3에서 실제 이미지 삭제 + DB에서 삭제

### ✅ 예외 처리
- [x] 파일 용량 제한, 확장자 필터링
- [x] 이미지 업로드 및 삭제 중 발생하는 예외를 `CustomAppException`으로 감싸서 처리
- [x] 이미지 삭제 실패 로그 처리