### PR TITLE
게시글 댓글 수 및 조회 수 기능 추가

### DIFF
--- a/src/main/java/com/example/popping/domain/Post.java
+++ b/src/main/java/com/example/popping/domain/Post.java
@@ -33,6 +33,12 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "board_id")
     private Board board;
 
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
+    @Column(nullable = false)
+    private int commentCount = 0;
+
     public void memberUpdate(String title, String content) {
         this.title = title;
         this.content = content;
@@ -43,6 +49,16 @@ public class Post extends BaseEntity {
         this.content = content;
         this.guestNickname = guestNickname;
         this.guestPasswordHash = guestPasswordHash;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        if (this.commentCount > 0) {
+            this.commentCount--;
+        }
     }
 
     public boolean isAuthor(User user) {

--- a/src/main/java/com/example/popping/dto/PostResponse.java
+++ b/src/main/java/com/example/popping/dto/PostResponse.java
@@ -16,6 +16,8 @@ public class PostResponse {
     private String boardName;
     private Long authorId;
     private String guestNickname;
+    private Long viewCount;
+    private int commentCount;
 
     public static PostResponse from(Post post) {
         return PostResponse.builder()
@@ -26,6 +28,8 @@ public class PostResponse {
                 .boardName(post.getBoard().getName())
                 .authorId(post.isGuest() ? null : post.getAuthor().getId())
                 .guestNickname(post.isGuest() ? post.getGuestNickname() : null)
+                .viewCount(post.getViewCount())
+                .commentCount(post.getCommentCount())
                 .build();
     }
 }

--- a/src/main/java/com/example/popping/repository/PostRepository.java
+++ b/src/main/java/com/example/popping/repository/PostRepository.java
@@ -3,10 +3,17 @@ package com.example.popping.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.popping.domain.Board;
 import com.example.popping.domain.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByBoard(Board board);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :postId")
+    void increaseViewCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/example/popping/service/CommentService.java
+++ b/src/main/java/com/example/popping/service/CommentService.java
@@ -34,6 +34,8 @@ public class CommentService {
 
         Comment comment = dto.toEntity(user.getUser(), post, parent);
         commentRepository.save(comment);
+
+        post.increaseCommentCount();
         return comment.getId();
     }
 
@@ -44,6 +46,8 @@ public class CommentService {
         String hashedPassword = passwordEncoder.encode(dto.getGuestPassword());
         Comment comment = dto.toEntity(post, parent, hashedPassword);
         commentRepository.save(comment);
+
+        post.increaseCommentCount();
         return comment.getId();
     }
 
@@ -55,6 +59,7 @@ public class CommentService {
                     "댓글 작성자가 아닙니다." + user.getUser().getLoginId());
         }
 
+        comment.getPost().decreaseCommentCount();
         commentRepository.delete(comment);
     }
 
@@ -71,6 +76,7 @@ public class CommentService {
                     "비밀번호가 일치하지 않습니다.");
         }
 
+        comment.getPost().decreaseCommentCount();
         commentRepository.delete(comment);
     }
 

--- a/src/main/java/com/example/popping/service/PostService.java
+++ b/src/main/java/com/example/popping/service/PostService.java
@@ -21,6 +21,7 @@ public class PostService {
 
     private final BoardService boardService;
     private final ImageService imageService;
+    private final ViewCountService viewCountService;
     private final PasswordEncoder passwordEncoder;
     private final PostRepository postRepository;
 
@@ -84,6 +85,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostResponse getPostResponse(Long postId) {
+        viewCountService.increaseView(postId);
         Post post = getPost(postId);
 
         return PostResponse.from(post);

--- a/src/main/java/com/example/popping/service/ViewCountService.java
+++ b/src/main/java/com/example/popping/service/ViewCountService.java
@@ -1,0 +1,19 @@
+package com.example.popping.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+
+import com.example.popping.repository.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ViewCountService {
+    private final PostRepository postRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void increaseView(Long postId) {
+        postRepository.increaseViewCount(postId);
+    }
+}


### PR DESCRIPTION
## :sparkles: 이슈 번호: #51 


## :bulb: 상세 내용:

게시글에 viewCount, commentCount 필드 추가
조회 수 증가 기능 구현 (JPQL으로 동시성 안전하게 증가 처리)
댓글 생성/삭제 시 commentCount 자동 증가/감소