### PR TITLE
JVM 플래그 최적화 (힙 고정 및 메모리 절감)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,17 @@ jib {
 	}
 	container {
 		environment = [TZ: "Asia/Seoul"]
-		jvmFlags = ['-XX:+UseContainerSupport', '-Dfile.encoding=UTF-8', '-Duser.timezone="Asia/Seoul"']
+		jvmFlags = [
+				'-XX:+UseContainerSupport',
+				'-Xms200m',
+				'-Xmx240m',
+				'-XX:ReservedCodeCacheSize=64m',
+				'-XX:MaxMetaspaceSize=128m',
+				'-XX:+UseStringDeduplication',
+				'-Dspring.profiles.active=dev',
+				'-Dfile.encoding=UTF-8',
+				'-Duser.timezone=Asia/Seoul'
+		]
 	}
 }
 


### PR DESCRIPTION
## :sparkles: 이슈 번호: #91 

## 변경 사항

`build.gradle` jib container jvmFlags 수정

| 플래그 | 변경 | 효과 |
|--------|------|------|
| `-Xms200m -Xmx240m` | 추가 | 힙 초기값 고정, 확장 GC 제거 |
| `-XX:ReservedCodeCacheSize=64m` | 추가 | 240m → 64m, 메모리 176 MiB 절감 |
| `-XX:MaxMetaspaceSize=128m` | 추가 | Metaspace 상한 명시 |
| `-XX:+UseStringDeduplication` | 추가 | 중복 String 제거, 힙 사용량 절감 |
| `timezone` 따옴표 | 수정 | `"Asia/Seoul"` → `Asia/Seoul` |

## 기대 효과

- 재기동 직후에도 warm 상태와 동일한 GC 성능 유지
- SWAP 사용량 감소
- cold start 시 P99 8,000ms → warm 수준으로 개선
