### PR TITLE
likeCount 비정규화 정합성 복구 배치 job 추가

### DIFF
--- a/src/main/java/com/example/popping/repository/CommentRepository.java
+++ b/src/main/java/com/example/popping/repository/CommentRepository.java
@@ -33,6 +33,24 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("UPDATE Comment c SET c.dislikeCount = c.dislikeCount + :delta WHERE c.id = :commentId")
     int updateDislikeCount(@Param("commentId") Long commentId, @Param("delta") int delta);
 
+    @Modifying
+    @Query(value = """
+            UPDATE comment c
+            JOIN (
+                SELECT target_id,
+                       SUM(CASE WHEN type = 'LIKE'    THEN 1 ELSE 0 END) AS like_count,
+                       SUM(CASE WHEN type = 'DISLIKE' THEN 1 ELSE 0 END) AS dislike_count
+                FROM likes
+                WHERE target_type = 'COMMENT'
+                GROUP BY target_id
+            ) l ON c.id = l.target_id
+            SET c.like_count    = l.like_count,
+                c.dislike_count = l.dislike_count
+            WHERE c.like_count != l.like_count
+               OR c.dislike_count != l.dislike_count
+            """, nativeQuery = true)
+    int reconcileLikeCounts();
+
     @Query(value = """
             WITH RECURSIVE comment_tree AS (
                 SELECT 

--- a/src/main/java/com/example/popping/repository/PostRepository.java
+++ b/src/main/java/com/example/popping/repository/PostRepository.java
@@ -38,4 +38,22 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Post p SET p.dislikeCount = p.dislikeCount + :delta WHERE p.id = :postId")
     void updateDislikeCount(@Param("postId") Long postId, @Param("delta") int delta);
+
+    @Modifying
+    @Query(value = """
+            UPDATE post p
+            JOIN (
+                SELECT target_id,
+                       SUM(CASE WHEN type = 'LIKE'    THEN 1 ELSE 0 END) AS like_count,
+                       SUM(CASE WHEN type = 'DISLIKE' THEN 1 ELSE 0 END) AS dislike_count
+                FROM likes
+                WHERE target_type = 'POST'
+                GROUP BY target_id
+            ) l ON p.id = l.target_id
+            SET p.like_count    = l.like_count,
+                p.dislike_count = l.dislike_count
+            WHERE p.like_count != l.like_count
+               OR p.dislike_count != l.dislike_count
+            """, nativeQuery = true)
+    int reconcileLikeCounts();
 }

--- a/src/main/java/com/example/popping/scheduler/LikeCountReconcileScheduler.java
+++ b/src/main/java/com/example/popping/scheduler/LikeCountReconcileScheduler.java
@@ -1,0 +1,31 @@
+package com.example.popping.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.example.popping.repository.CommentRepository;
+import com.example.popping.repository.PostRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeCountReconcileScheduler {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 4 * * *")
+    public void reconcileLikeCounts() {
+        int fixedPosts = postRepository.reconcileLikeCounts();
+        int fixedComments = commentRepository.reconcileLikeCounts();
+        if (fixedPosts > 0 || fixedComments > 0) {
+            log.warn("likeCount reconcile: fixed {} posts, {} comments", fixedPosts, fixedComments);
+        } else {
+            log.info("likeCount reconcile: no discrepancies found");
+        }
+    }
+}

--- a/src/test/java/com/example/popping/LikeCountReconcileIntegrationTest.java
+++ b/src/test/java/com/example/popping/LikeCountReconcileIntegrationTest.java
@@ -1,0 +1,123 @@
+package com.example.popping;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.example.popping.domain.Comment;
+import com.example.popping.domain.Like;
+import com.example.popping.domain.Post;
+import com.example.popping.domain.User;
+import com.example.popping.domain.UserPrincipal;
+import com.example.popping.domain.UserRole;
+import com.example.popping.domain.Board;
+import com.example.popping.dto.LikeRequest;
+import com.example.popping.repository.BoardRepository;
+import com.example.popping.repository.CommentRepository;
+import com.example.popping.repository.PostRepository;
+import com.example.popping.repository.UserRepository;
+import com.example.popping.scheduler.LikeCountReconcileScheduler;
+import com.example.popping.service.LikeService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class LikeCountReconcileIntegrationTest {
+
+    @Autowired LikeCountReconcileScheduler scheduler;
+    @Autowired PostRepository postRepository;
+    @Autowired CommentRepository commentRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired BoardRepository boardRepository;
+    @Autowired LikeService likeService;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("post.likeCount가 likes 테이블과 불일치할 때 배치가 보정한다")
+    void post_likeCount_불일치_시_보정된다() {
+        String unique = String.valueOf(System.nanoTime());
+        User user = userRepository.saveAndFlush(
+                User.create("login-" + unique, "nick-" + unique, "pw-" + unique, UserRole.USER));
+        Board board = boardRepository.saveAndFlush(
+                Board.create("board-" + unique, "desc", "slug-" + unique, user));
+        Post post = postRepository.saveAndFlush(
+                Post.createMemberPost("title", "content", user, board));
+
+        likeService.addLike(
+                new LikeRequest(post.getId(), Like.TargetType.POST, Like.Type.LIKE, null),
+                principal(user.getId()));
+
+        // 강제 불일치: likeCount를 0으로 덮어써 likes 테이블과 어긋나게 만든다
+        jdbcTemplate.update("UPDATE post SET like_count = 0 WHERE id = ?", post.getId());
+        assertThat(postRepository.findById(post.getId()).orElseThrow().getLikeCount()).isEqualTo(0);
+
+        // when
+        scheduler.reconcileLikeCounts();
+
+        // then
+        assertThat(postRepository.findById(post.getId()).orElseThrow().getLikeCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("comment.likeCount가 likes 테이블과 불일치할 때 배치가 보정한다")
+    void comment_likeCount_불일치_시_보정된다() {
+        String unique = String.valueOf(System.nanoTime());
+        User user = userRepository.saveAndFlush(
+                User.create("login-" + unique, "nick-" + unique, "pw-" + unique, UserRole.USER));
+        Board board = boardRepository.saveAndFlush(
+                Board.create("board-" + unique, "desc", "slug-" + unique, user));
+        Post post = postRepository.saveAndFlush(
+                Post.createMemberPost("title", "content", user, board));
+        Comment comment = commentRepository.saveAndFlush(
+                Comment.createMemberComment("comment", user, post, null));
+
+        likeService.addLike(
+                new LikeRequest(comment.getId(), Like.TargetType.COMMENT, Like.Type.LIKE, null),
+                principal(user.getId()));
+
+        // 강제 불일치
+        jdbcTemplate.update("UPDATE comment SET like_count = 0 WHERE id = ?", comment.getId());
+        assertThat(commentRepository.findById(comment.getId()).orElseThrow().getLikeCount()).isEqualTo(0);
+
+        // when
+        scheduler.reconcileLikeCounts();
+
+        // then
+        assertThat(commentRepository.findById(comment.getId()).orElseThrow().getLikeCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("불일치가 없으면 배치 실행 후에도 likeCount가 변경되지 않는다")
+    void 불일치_없으면_likeCount_변경_없다() {
+        String unique = String.valueOf(System.nanoTime());
+        User user = userRepository.saveAndFlush(
+                User.create("login-" + unique, "nick-" + unique, "pw-" + unique, UserRole.USER));
+        Board board = boardRepository.saveAndFlush(
+                Board.create("board-" + unique, "desc", "slug-" + unique, user));
+        Post post = postRepository.saveAndFlush(
+                Post.createMemberPost("title", "content", user, board));
+
+        likeService.addLike(
+                new LikeRequest(post.getId(), Like.TargetType.POST, Like.Type.LIKE, null),
+                principal(user.getId()));
+
+        int likeCountBefore = postRepository.findById(post.getId()).orElseThrow().getLikeCount();
+
+        // when
+        scheduler.reconcileLikeCounts();
+
+        // then
+        int likeCountAfter = postRepository.findById(post.getId()).orElseThrow().getLikeCount();
+        assertThat(likeCountAfter).isEqualTo(likeCountBefore);
+    }
+
+    private UserPrincipal principal(Long userId) {
+        UserPrincipal p = mock(UserPrincipal.class);
+        when(p.getUserId()).thenReturn(userId);
+        return p;
+    }
+}


### PR DESCRIPTION
## :sparkles: 이슈 번호: #109 


## 배경                                                                                                                                                                                                                           
                                                                                                                                                                                                                                    
  `post.likeCount`, `comment.likeCount`는 `likes` 테이블과 별도로 관리되는                                                                                                                                                          
  비정규화 컬럼이다. 정상 흐름에서는 `ON DUPLICATE KEY UPDATE`의 affected rows                                                                                                                                                      
  기반으로 실제 insert/delete 시에만 증감하지만, 예기치 못한 장애나 버그 발생 시
  두 값이 어긋날 수 있는 구조적 위험이 존재했다.

  불일치를 감지하거나 복구하는 수단이 없었기 때문에 숫자가 틀어져도
  서비스가 인지할 방법이 없었다.

  ## 해결

  매일 새벽 4시에 `likes` 테이블을 재집계해 비정규화 컬럼과 비교하고,
  불일치가 있으면 자동으로 보정하는 배치 job을 추가했다.

  ```sql
  -- post 기준 (comment도 동일한 구조)
  UPDATE post p
  JOIN (
      SELECT target_id,
             SUM(CASE WHEN type = 'LIKE'    THEN 1 ELSE 0 END) AS like_count,
             SUM(CASE WHEN type = 'DISLIKE' THEN 1 ELSE 0 END) AS dislike_count
      FROM likes
      WHERE target_type = 'POST'
      GROUP BY target_id
  ) l ON p.id = l.target_id
  SET p.like_count    = l.like_count,
      p.dislike_count = l.dislike_count
  WHERE p.like_count != l.like_count
     OR p.dislike_count != l.dislike_count
```

  불일치 발생 시 보정 건수를 warn 로그로 남겨 이상 징후를 추적할 수 있다.

  변경 파일

  - PostRepository — reconcileLikeCounts() 추가
  - CommentRepository — reconcileLikeCounts() 추가
  - LikeCountReconcileScheduler — 신규 생성 (매일 04:00 실행)
  - LikeCountReconcileIntegrationTest — 통합 테스트 3케이스
    - post.likeCount 불일치 시 보정
    - comment.likeCount 불일치 시 보정
    - 불일치 없으면 likeCount 변경 없음
