### PR TITLE
게스트 쿠키 클라이언트 위조 가능 취약점 제거

### DIFF
--- a/src/main/java/com/example/popping/filter/GuestIdentifierFilter.java
+++ b/src/main/java/com/example/popping/filter/GuestIdentifierFilter.java
@@ -1,0 +1,100 @@
+package com.example.popping.filter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import com.example.popping.service.GuestIdentifierService;
+
+@Component
+@RequiredArgsConstructor
+public class GuestIdentifierFilter extends OncePerRequestFilter {
+
+    public static final String GUEST_UUID_ATTR = "guestUuid";
+    private static final String COOKIE_NAME = "guestIdentifier";
+
+    private final GuestIdentifierService guestIdentifierService;
+
+    @Value("${guest.identifier.secure-cookie:false}")
+    private boolean secureCookie;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        String cookieValue = extractCookieValue(request);
+        Optional<String> uuid = guestIdentifierService.extractUuid(cookieValue);
+
+        if (uuid.isEmpty()) {
+            cookieValue = guestIdentifierService.generate();
+            uuid = guestIdentifierService.extractUuid(cookieValue);
+            ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, cookieValue)
+                    .secure(secureCookie)
+                    .path("/")
+                    .maxAge(Duration.ofDays(365))
+                    .sameSite("Lax")
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        }
+
+        request.setAttribute(GUEST_UUID_ATTR, uuid.get());
+
+        // @CookieValue("guestIdentifier")로 읽는 MVC 컨트롤러에 UUID만 전달
+        chain.doFilter(new UuidCookieWrapper(request, cookieValue, uuid.get()), response);
+    }
+
+    private String extractCookieValue(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(c -> COOKIE_NAME.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * guestIdentifier 쿠키 값을 UUID로 교체해서 @CookieValue 컨트롤러에 전달.
+     */
+    private static class UuidCookieWrapper extends HttpServletRequestWrapper {
+
+        private final Cookie[] cookies;
+
+        UuidCookieWrapper(HttpServletRequest request, String originalValue, String uuid) {
+            super(request);
+            Cookie[] original = request.getCookies();
+            if (original == null) {
+                Cookie c = new Cookie(COOKIE_NAME, uuid);
+                cookies = new Cookie[]{ c };
+                return;
+            }
+            cookies = Arrays.stream(original)
+                    .map(c -> {
+                        if (!COOKIE_NAME.equals(c.getName())) return c;
+                        Cookie replaced = new Cookie(c.getName(), uuid);
+                        replaced.setPath(c.getPath());
+                        return replaced;
+                    })
+                    .toArray(Cookie[]::new);
+        }
+
+        @Override
+        public Cookie[] getCookies() {
+            return cookies;
+        }
+    }
+}

--- a/src/main/java/com/example/popping/service/CommentService.java
+++ b/src/main/java/com/example/popping/service/CommentService.java
@@ -42,6 +42,7 @@ public class CommentService {
     private final CacheManager cacheManager;
     private final TransactionTemplate readOnlyTx;
     private final ApplicationEventPublisher eventPublisher;
+    private final GuestIdentifierService guestIdentifierService;
 
     public Long createMemberComment(Long postId,
                                     MemberCommentCreateRequest dto,
@@ -126,7 +127,12 @@ public class CommentService {
             base = mergeLikeCounts(base);
         }
 
-        return mergePersonalReaction(base, principal, guestIdentifier);
+        return mergePersonalReaction(base, principal, resolveGuestIdentifier(guestIdentifier));
+    }
+
+    private String resolveGuestIdentifier(String raw) {
+        if (raw == null) return null;
+        return guestIdentifierService.extractUuid(raw).orElse(raw);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/popping/service/GuestIdentifierService.java
+++ b/src/main/java/com/example/popping/service/GuestIdentifierService.java
@@ -1,0 +1,59 @@
+package com.example.popping.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GuestIdentifierService {
+
+    @Value("${guest.identifier.hmac-secret}")
+    private String secret;
+
+    /**
+     * UUID + HMAC 서명을 조합한 쿠키 값 생성.
+     * 형태: "uuid.base64url(hmac-sha256(uuid, secret))"
+     */
+    public String generate() {
+        String uuid = UUID.randomUUID().toString();
+        return uuid + "." + sign(uuid);
+    }
+
+    /**
+     * 쿠키 값에서 서명 검증 후 UUID 반환.
+     * 서명이 유효하지 않으면 empty 반환.
+     */
+    public Optional<String> extractUuid(String cookieValue) {
+        if (cookieValue == null || cookieValue.isBlank()) {
+            return Optional.empty();
+        }
+        int dotIdx = cookieValue.lastIndexOf('.');
+        if (dotIdx < 0) {
+            return Optional.empty();
+        }
+        String uuid = cookieValue.substring(0, dotIdx);
+        String sig = cookieValue.substring(dotIdx + 1);
+        boolean valid = MessageDigest.isEqual(
+                sign(uuid).getBytes(StandardCharsets.UTF_8),
+                sig.getBytes(StandardCharsets.UTF_8));
+        return valid ? Optional.of(uuid) : Optional.empty();
+    }
+
+    private String sign(String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("HMAC signing failed", e);
+        }
+    }
+}

--- a/src/main/java/com/example/popping/service/LikeService.java
+++ b/src/main/java/com/example/popping/service/LikeService.java
@@ -22,10 +22,11 @@ public class LikeService {
     private final PostService postService;
     private final CommentService commentService;
     private final UserService userService;
+    private final GuestIdentifierService guestIdentifierService;
 
     public LikeResponse addLike(LikeRequest req, UserPrincipal principal) {
         User user = getUser(principal);
-        String guestIdentifier = req.guestIdentifier();
+        String guestIdentifier = resolveGuestIdentifier(req.guestIdentifier());
         validateActor(user, guestIdentifier);
 
         int inserted = likeRepository.insertIgnore(
@@ -45,7 +46,7 @@ public class LikeService {
 
     public LikeResponse removeLike(LikeRequest req, UserPrincipal principal) {
         User user = getUser(principal);
-        String guestIdentifier = req.guestIdentifier();
+        String guestIdentifier = resolveGuestIdentifier(req.guestIdentifier());
         validateActor(user, guestIdentifier);
 
         int deleted = likeRepository.deleteByActor(
@@ -66,6 +67,15 @@ public class LikeService {
     private User getUser(UserPrincipal principal) {
         if (principal == null) return null;
         return userService.getLoginUserById(principal.getUserId());
+    }
+
+    /**
+     * guestIdentifier가 "uuid.signature" 형태면 서명 검증 후 UUID만 반환.
+     * 서명이 없는 구형 값이거나 null이면 그대로 반환.
+     */
+    private String resolveGuestIdentifier(String raw) {
+        if (raw == null) return null;
+        return guestIdentifierService.extractUuid(raw).orElse(raw);
     }
 
     private void validateActor(User user, String guestIdentifier) {

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -212,15 +212,5 @@
     </div>
 </footer>
 
-<script>
-    (function syncGuestIdentifierCookie() {
-        let guestId = localStorage.getItem('guestIdentifier');
-        if (!guestId) {
-            guestId = 'guest-' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-            localStorage.setItem('guestIdentifier', guestId);
-        }
-        document.cookie = `guestIdentifier=${encodeURIComponent(guestId)}; path=/; max-age=31536000; SameSite=Lax`;
-    })();
-</script>
 </body>
 </html>

--- a/src/main/resources/templates/post/detail.html
+++ b/src/main/resources/templates/post/detail.html
@@ -693,18 +693,10 @@
     }
 
     function getGuestIdentifier() {
-        let guestId = localStorage.getItem('guestIdentifier');
-        if (!guestId) {
-            guestId = 'guest-' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-            localStorage.setItem('guestIdentifier', guestId);
-        }
-        return guestId;
-    }
-
-    function syncGuestIdentifierCookie() {
-        const guestId = getGuestIdentifier();
-        document.cookie = `guestIdentifier=${encodeURIComponent(guestId)}; path=/; max-age=31536000; SameSite=Lax`;
-        return guestId;
+        const match = document.cookie.split(';')
+            .map(c => c.trim())
+            .find(c => c.startsWith('guestIdentifier='));
+        return match ? decodeURIComponent(match.split('=')[1]) : null;
     }
 
     // 댓글 관련 함수들
@@ -1122,7 +1114,6 @@
 
     // 이벤트 리스너 등록
     document.addEventListener('DOMContentLoaded', function() {
-        syncGuestIdentifierCookie();
         // WebSocket 연결
         connect();
 

--- a/src/test/java/com/example/popping/controller/BoardControllerTest.java
+++ b/src/test/java/com/example/popping/controller/BoardControllerTest.java
@@ -1,5 +1,8 @@
 package com.example.popping.controller;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +23,7 @@ import com.example.popping.service.PostService;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,6 +41,15 @@ class BoardControllerTest {
 
     @MockitoBean
     private PostService postService;
+
+    @MockitoBean
+    private com.example.popping.service.GuestIdentifierService guestIdentifierService;
+
+    @BeforeEach
+    void setUp() {
+        when(guestIdentifierService.generate()).thenReturn("test-uuid.test-sig");
+        when(guestIdentifierService.extractUuid(any())).thenReturn(Optional.of("test-uuid"));
+    }
 
     @Test
     @WithMockUser

--- a/src/test/java/com/example/popping/controller/PostControllerTest.java
+++ b/src/test/java/com/example/popping/controller/PostControllerTest.java
@@ -37,6 +37,9 @@ class PostControllerTest {
     @MockBean
     CommentService commentService;
 
+    @MockBean
+    com.example.popping.service.GuestIdentifierService guestIdentifierService;
+
     @BeforeEach
     void setUp() {
         when(htmlSanitizer.sanitize(anyString()))

--- a/src/test/java/com/example/popping/controller/commentControllerTest.java
+++ b/src/test/java/com/example/popping/controller/commentControllerTest.java
@@ -1,5 +1,8 @@
 package com.example.popping.controller;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +20,7 @@ import com.example.popping.service.CommentService;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,6 +34,15 @@ class CommentControllerTest {
 
     @MockitoBean
     private CommentService commentService;
+
+    @MockitoBean
+    private com.example.popping.service.GuestIdentifierService guestIdentifierService;
+
+    @BeforeEach
+    void setUp() {
+        when(guestIdentifierService.generate()).thenReturn("test-uuid.test-sig");
+        when(guestIdentifierService.extractUuid(any())).thenReturn(Optional.of("test-uuid"));
+    }
 
     @Test
     @WithMockUser

--- a/src/test/java/com/example/popping/filter/GuestIdentifierFilterTest.java
+++ b/src/test/java/com/example/popping/filter/GuestIdentifierFilterTest.java
@@ -1,0 +1,100 @@
+package com.example.popping.filter;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.popping.service.GuestIdentifierService;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GuestIdentifierFilterTest {
+
+    private MockMvc mockMvc;
+    private GuestIdentifierService guestIdentifierService;
+
+    @BeforeEach
+    void setUp() {
+        guestIdentifierService = new GuestIdentifierService();
+        ReflectionTestUtils.setField(guestIdentifierService, "secret", "test-secret");
+
+        GuestIdentifierFilter filter = new GuestIdentifierFilter(guestIdentifierService);
+        ReflectionTestUtils.setField(filter, "secureCookie", false);
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new DummyController())
+                .addFilter(filter)
+                .build();
+    }
+
+    @Test
+    @DisplayName("쿠키 없음: Set-Cookie로 새 guestIdentifier를 발급한다")
+    void noCookie_issuesNewCookie() throws Exception {
+        mockMvc.perform(get("/test"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("guestIdentifier=")));
+    }
+
+    @Test
+    @DisplayName("유효한 쿠키: Set-Cookie 재발급 없음")
+    void validCookie_noReissue() throws Exception {
+        String validCookie = guestIdentifierService.generate();
+
+        mockMvc.perform(get("/test")
+                        .cookie(new Cookie("guestIdentifier", validCookie)))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist(HttpHeaders.SET_COOKIE));
+    }
+
+    @Test
+    @DisplayName("서명 변조된 쿠키: 새 쿠키를 재발급한다")
+    void tamperedCookie_reissues() throws Exception {
+        mockMvc.perform(get("/test")
+                        .cookie(new Cookie("guestIdentifier", "some-uuid.INVALIDSIG")))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("guestIdentifier=")));
+    }
+
+    @Test
+    @DisplayName("구형 guest-xxxx 형태 쿠키: 새 쿠키를 재발급한다")
+    void legacyCookie_reissues() throws Exception {
+        mockMvc.perform(get("/test")
+                        .cookie(new Cookie("guestIdentifier", "guest-abc123def456")))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("guestIdentifier=")));
+    }
+
+    @Test
+    @DisplayName("발급된 쿠키는 SameSite=Lax 속성을 포함한다")
+    void issuedCookie_hasSameSiteLax() throws Exception {
+        mockMvc.perform(get("/test"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("SameSite=Lax")));
+    }
+
+    @Test
+    @DisplayName("발급된 쿠키는 path=/ 속성을 포함한다")
+    void issuedCookie_hasRootPath() throws Exception {
+        mockMvc.perform(get("/test"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Path=/")));
+    }
+
+    @RestController
+    static class DummyController {
+        @GetMapping("/test")
+        String test() {
+            return "ok";
+        }
+    }
+}

--- a/src/test/java/com/example/popping/service/CacheTests.java
+++ b/src/test/java/com/example/popping/service/CacheTests.java
@@ -44,6 +44,7 @@ class CacheTests {
     @Mock UserService userService;
     @Mock CommentRepository commentRepository;
     @Mock PasswordEncoder passwordEncoder;
+    @Mock GuestIdentifierService guestIdentifierService;
 
     @InjectMocks CommentService commentService;
 

--- a/src/test/java/com/example/popping/service/CommentCacheStampedeTest.java
+++ b/src/test/java/com/example/popping/service/CommentCacheStampedeTest.java
@@ -66,9 +66,14 @@ class CommentCacheStampedeTest {
             }
         };
 
+        GuestIdentifierService guestIdentifierService = new GuestIdentifierService();
+        org.springframework.test.util.ReflectionTestUtils.setField(
+                guestIdentifierService, "secret", "test-secret");
+
         commentService = new CommentService(
                 postService, userService, commentRepository,
-                likeRepository, guestPasswordEncoder, cacheManager, readOnlyTx, eventPublisher
+                likeRepository, guestPasswordEncoder, cacheManager, readOnlyTx, eventPublisher,
+                guestIdentifierService
         );
     }
 

--- a/src/test/java/com/example/popping/service/CommentServiceTest.java
+++ b/src/test/java/com/example/popping/service/CommentServiceTest.java
@@ -48,6 +48,7 @@ class CommentServiceTest {
     @Mock Cache cache;
     @Mock TransactionTemplate readOnlyTx;
     @Mock ApplicationEventPublisher eventPublisher;
+    @Mock GuestIdentifierService guestIdentifierService;
 
     @InjectMocks CommentService commentService;
 

--- a/src/test/java/com/example/popping/service/GuestIdentifierServiceTest.java
+++ b/src/test/java/com/example/popping/service/GuestIdentifierServiceTest.java
@@ -1,0 +1,92 @@
+package com.example.popping.service;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GuestIdentifierServiceTest {
+
+    private GuestIdentifierService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new GuestIdentifierService();
+        ReflectionTestUtils.setField(service, "secret", "test-secret-key");
+    }
+
+    @Test
+    @DisplayName("generate(): uuid.signature 형태의 값을 반환한다")
+    void generate_returnsUuidDotSignatureFormat() {
+        String value = service.generate();
+
+        assertTrue(value.contains("."), "uuid.sig 형태여야 한다");
+        String[] parts = value.split("\\.", 2);
+        assertEquals(2, parts.length);
+        assertFalse(parts[0].isBlank());
+        assertFalse(parts[1].isBlank());
+    }
+
+    @Test
+    @DisplayName("generate()로 만든 값은 extractUuid()로 UUID를 복원할 수 있다")
+    void extractUuid_validSignature_returnsUuid() {
+        String generated = service.generate();
+        String expectedUuid = generated.substring(0, generated.lastIndexOf('.'));
+
+        Optional<String> result = service.extractUuid(generated);
+
+        assertTrue(result.isPresent());
+        assertEquals(expectedUuid, result.get());
+    }
+
+    @Test
+    @DisplayName("extractUuid(): 서명이 변조된 경우 empty를 반환한다")
+    void extractUuid_tamperedSignature_returnsEmpty() {
+        String generated = service.generate();
+        String tampered = generated + "X";
+
+        assertTrue(service.extractUuid(tampered).isEmpty());
+    }
+
+    @Test
+    @DisplayName("extractUuid(): 구형 guest-xxxx 형태(dot 없음)는 empty를 반환한다")
+    void extractUuid_legacyFormat_returnsEmpty() {
+        assertTrue(service.extractUuid("guest-abc123def456").isEmpty());
+    }
+
+    @Test
+    @DisplayName("extractUuid(): null은 empty를 반환한다")
+    void extractUuid_null_returnsEmpty() {
+        assertTrue(service.extractUuid(null).isEmpty());
+    }
+
+    @Test
+    @DisplayName("extractUuid(): 공백 문자열은 empty를 반환한다")
+    void extractUuid_blank_returnsEmpty() {
+        assertTrue(service.extractUuid("   ").isEmpty());
+    }
+
+    @Test
+    @DisplayName("extractUuid(): 다른 secret으로 서명한 값은 empty를 반환한다")
+    void extractUuid_differentSecret_returnsEmpty() {
+        GuestIdentifierService other = new GuestIdentifierService();
+        ReflectionTestUtils.setField(other, "secret", "other-secret");
+
+        String fromOther = other.generate();
+
+        assertTrue(service.extractUuid(fromOther).isEmpty());
+    }
+
+    @Test
+    @DisplayName("generate()를 두 번 호출하면 서로 다른 값을 반환한다")
+    void generate_producesUniqueValues() {
+        String first = service.generate();
+        String second = service.generate();
+
+        assertNotEquals(first, second);
+    }
+}

--- a/src/test/java/com/example/popping/service/LikeServiceTest.java
+++ b/src/test/java/com/example/popping/service/LikeServiceTest.java
@@ -27,6 +27,7 @@ class LikeServiceTest {
     @Mock PostService postService;
     @Mock CommentService commentService;
     @Mock UserService userService;
+    @Mock GuestIdentifierService guestIdentifierService;
 
     @InjectMocks LikeService likeService;
 


### PR DESCRIPTION
## :sparkles: 이슈 번호: #111 


  ## 변경 내용                                                                                                                                                                                                                      
                                                                                                                                                                                                                                    
  ### 신규 파일

  - **`GuestIdentifierService`** — `UUID.randomUUID()` + HMAC-SHA256 서명을 결합한 쿠키 값(`uuid.base64url(sig)`) 생성 및 검증
  - **`GuestIdentifierFilter`** (`OncePerRequestFilter`) — 모든 HTTP 요청에서 쿠키를 검증하고, 없거나 서명이 유효하지 않으면 새로 발급
    - `Secure`, `SameSite=Lax`, `Max-Age=365d` 속성 적용
    - `UuidCookieWrapper`로 `@CookieValue` 컨트롤러에는 순수 UUID만 전달 (서명 제거)

  ### 기존 파일 수정

  | 파일 | 변경 내용 |
  |---|---|
  | `LikeService` | `resolveGuestIdentifier()` 추가 — STOMP/REST body의 signed value에서 UUID 추출 |
  | `CommentService` | `GuestIdentifierService` 주입, `resolveGuestIdentifier()` 추가 — 쿼리 파라미터의 signed value에서 UUID 추출 |
  | `application.properties` | `guest.identifier.hmac-secret`, `guest.identifier.secure-cookie` 설정 추가 |
  | `board/detail.html` | 클라이언트 쿠키 발급 스크립트 제거 |
  | `post/detail.html` | `getGuestIdentifier()`를 `document.cookie` 읽기로 교체, `syncGuestIdentifierCookie()` 제거 |

  ## 보안 흐름

  최초 요청
  └─ GuestIdentifierFilter
     ├─ 쿠키 없음 또는 서명 불일치
     │  └─ GuestIdentifierService.generate() → "uuid.hmac" 발급 → Set-Cookie
     └─ 서명 유효
        └─ UUID 추출 → request attribute 설정

  이후 요청 (JS → 서버)
  ├─ HTTP (loadComments): guestIdentifier 쿼리 파라미터로 "uuid.hmac" 전달
  │  └─ CommentService.resolveGuestIdentifier() → UUID 추출 후 사용
  └─ STOMP (좋아요): LikeRequest.guestIdentifier = "uuid.hmac"
     └─ LikeService.resolveGuestIdentifier() → UUID 추출 후 사용

  ## 수용 기준

  - [x] 서명이 없거나 변조된 쿠키로 요청 시 새 쿠키가 발급된다
  - [x] 유효한 쿠키로는 정상 동작한다
  - [x] 클라이언트 JS가 더 이상 `Math.random()` UUID를 생성하지 않는다
  - [x] `hmac-secret`은 환경변수/Secret으로 관리한다 (운영 환경 필수)

  ## 비고

  - `HttpOnly`는 **의도적으로 미적용** — STOMP 요청 body에 쿠키 값을 포함해야 하므로 JS에서 읽을 수 있어야 함
  - 운영 환경에서는 `guest.identifier.secure-cookie=true`로 설정할 것
  - 기존 클라이언트 발급 구형 쿠키(`guest-xxxx` 형태)는 서명 불일치로 자동 갱신됨

## 테스트

  - `GuestIdentifierServiceTest` — generate/extractUuid 정상·변조·구형·null 케이스 단위 테스트
  - `GuestIdentifierFilterTest` — 쿠키 없음·유효·변조·구형 시 발급 여부 필터 테스트