### PR TITLE
조회수 flush 후 캐시 미갱신으로 view_count가 리셋되는 버그

### DIFF
--- a/src/main/java/com/example/popping/service/ViewCountService.java
+++ b/src/main/java/com/example/popping/service/ViewCountService.java
@@ -8,12 +8,15 @@ import java.util.concurrent.atomic.LongAdder;
 
 import jakarta.annotation.PreDestroy;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.example.popping.config.app.CacheConfig;
 import com.example.popping.repository.PostRepository;
 
 @Slf4j
@@ -23,6 +26,7 @@ public class ViewCountService {
 
     private final PostRepository postRepository;
     private final TransactionTemplate txTemplate;
+    private final CacheManager cacheManager;
 
     private final ConcurrentHashMap<Long, LongAdder> pendingCounts = new ConcurrentHashMap<>();
 
@@ -74,7 +78,18 @@ public class ViewCountService {
         }
 
         if (flushed > 0) {
+            evictPostDetailCache(batch);
             log.info("viewCount flush: updated {} posts", flushed);
+        }
+    }
+
+    private void evictPostDetailCache(List<Map.Entry<Long, Long>> batch) {
+        Cache cache = cacheManager.getCache(CacheConfig.POST_DETAIL_CACHE);
+        if (cache == null) {
+            return;
+        }
+        for (Map.Entry<Long, Long> entry : batch) {
+            cache.evict(entry.getKey());
         }
     }
 

--- a/src/test/java/com/example/popping/service/ViewCountServiceTest.java
+++ b/src/test/java/com/example/popping/service/ViewCountServiceTest.java
@@ -13,12 +13,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.example.popping.config.app.CacheConfig;
 import com.example.popping.repository.PostRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +34,9 @@ class ViewCountServiceTest {
 
     @Mock
     TransactionTemplate txTemplate;
+
+    @Mock
+    CacheManager cacheManager;
 
     @InjectMocks
     ViewCountService viewCountService;
@@ -147,5 +154,48 @@ class ViewCountServiceTest {
 
         verify(postRepository).increaseViewCountBy(1L, 1L);
         assertThat(viewCountService.getPendingCount(1L)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("flushViewCounts: flush 후 postDetail 캐시를 evict한다")
+    void flushViewCounts_evictsPostDetailCache() {
+        Cache mockCache = mock(Cache.class);
+        when(cacheManager.getCache(CacheConfig.POST_DETAIL_CACHE)).thenReturn(mockCache);
+
+        viewCountService.increaseView(1L);
+        viewCountService.increaseView(2L);
+
+        viewCountService.flushViewCounts();
+
+        verify(mockCache).evict(1L);
+        verify(mockCache).evict(2L);
+    }
+
+    @Test
+    @DisplayName("flushViewCounts: 캐시가 없으면 evict를 건너뛴다")
+    void flushViewCounts_noCacheAvailable_skipsEviction() {
+        when(cacheManager.getCache(CacheConfig.POST_DETAIL_CACHE)).thenReturn(null);
+
+        viewCountService.increaseView(1L);
+
+        viewCountService.flushViewCounts();
+
+        verify(postRepository).increaseViewCountBy(1L, 1L);
+        verify(cacheManager).getCache(CacheConfig.POST_DETAIL_CACHE);
+    }
+
+    @Test
+    @DisplayName("flushViewCounts: DB 오류 시 캐시를 evict하지 않는다")
+    void flushViewCounts_dbError_doesNotEvictCache() {
+        Cache mockCache = mock(Cache.class);
+        when(cacheManager.getCache(CacheConfig.POST_DETAIL_CACHE)).thenReturn(mockCache);
+        doThrow(new RuntimeException("DB error")).when(postRepository).increaseViewCountBy(1L, 2L);
+
+        viewCountService.increaseView(1L);
+        viewCountService.increaseView(1L);
+
+        viewCountService.flushViewCounts();
+
+        verify(mockCache, never()).evict(1L);
     }
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #120 


## 수정 파일

- `ViewCountService.java` — `CacheManager` 주입, `evictPostDetailCache()` 메서드 추가
- `ViewCountServiceTest.java` — `@Mock CacheManager` 추가, 캐시 eviction 테스트 3건 추가

## 테스트

- [x] `flushViewCounts_evictsPostDetailCache` — flush 후 캐시 evict 검증
- [x] `flushViewCounts_noCacheAvailable_skipsEviction` — 캐시 null 시 안전하게 스킵
- [x] `flushViewCounts_dbError_doesNotEvictCache` — DB 오류 시 캐시 미삭제 검증
- [x] 기존 테스트 전체 통과 확인