### PR TITLE
MySQL Read Replica 라우팅 (LazyConnectionDataSourceProxy)

### DIFF
--- a/src/main/java/com/example/popping/config/db/DataSourceConfig.java
+++ b/src/main/java/com/example/popping/config/db/DataSourceConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
@@ -13,6 +14,7 @@ import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
+@ConditionalOnProperty(prefix = "app.datasource.write", name = "jdbc-url")
 public class DataSourceConfig {
 
 	@Bean

--- a/src/main/java/com/example/popping/config/db/DataSourceConfig.java
+++ b/src/main/java/com/example/popping/config/db/DataSourceConfig.java
@@ -1,0 +1,43 @@
+package com.example.popping.config.db;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+@Configuration
+public class DataSourceConfig {
+
+	@Bean
+	@ConfigurationProperties(prefix = "app.datasource.write")
+	public DataSource writeDataSource() {
+		return DataSourceBuilder.create()
+				.type(HikariDataSource.class)
+				.build();
+	}
+
+	@Bean
+	@ConfigurationProperties(prefix = "app.datasource.read")
+	public DataSource readDataSource() {
+		return DataSourceBuilder.create()
+				.type(HikariDataSource.class)
+				.build();
+	}
+
+	@Bean
+	@Primary
+	public DataSource dataSource(
+			@Qualifier("writeDataSource") DataSource writeDataSource,
+			@Qualifier("readDataSource") DataSource readDataSource) {
+		LazyConnectionDataSourceProxy proxy = new LazyConnectionDataSourceProxy(writeDataSource);
+		proxy.setReadOnlyDataSource(readDataSource);
+		return proxy;
+	}
+}


### PR DESCRIPTION
## Summary
- `DataSourceConfig`에서 write/read DataSource를 분리하고 `LazyConnectionDataSourceProxy`로 자동 라우팅
- `@Transactional(readOnly=true)` → Replica, 그 외 → Master로 연결
- Spring 6.1.2+ 네이티브 기능 활용, 별도 라이브러리 불필요

## 변경 사항
- `src/main/java/com/example/popping/config/db/DataSourceConfig.java` (신규)

## Test plan
- [x] 앱 기동 후 게시글 조회(readOnly) 시 Replica로 쿼리 확인 (general_log)
- [x] 게시글 작성(write) 시 Master로 쿼리 확인
- [x] 1000 vuser 부하테스트 Before/After 비교

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)