### PR TITLE
feat: Replication Lag 완화 — 병렬 복제 + Sticky Primary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.jsoup:jsoup:1.16.1'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/src/main/java/com/example/popping/config/db/DataSourceConfig.java
+++ b/src/main/java/com/example/popping/config/db/DataSourceConfig.java
@@ -34,12 +34,19 @@ public class DataSourceConfig {
 	}
 
 	@Bean
+	public StickyAwareRoutingDataSource routingReadDataSource(
+			@Qualifier("writeDataSource") DataSource writeDataSource,
+			@Qualifier("readDataSource") DataSource readDataSource) {
+		return new StickyAwareRoutingDataSource(writeDataSource, readDataSource);
+	}
+
+	@Bean
 	@Primary
 	public DataSource dataSource(
 			@Qualifier("writeDataSource") DataSource writeDataSource,
-			@Qualifier("readDataSource") DataSource readDataSource) {
+			StickyAwareRoutingDataSource routingReadDataSource) {
 		LazyConnectionDataSourceProxy proxy = new LazyConnectionDataSourceProxy(writeDataSource);
-		proxy.setReadOnlyDataSource(readDataSource);
+		proxy.setReadOnlyDataSource(routingReadDataSource);
 		return proxy;
 	}
 }

--- a/src/main/java/com/example/popping/config/db/StickyAwareRoutingDataSource.java
+++ b/src/main/java/com/example/popping/config/db/StickyAwareRoutingDataSource.java
@@ -1,0 +1,39 @@
+package com.example.popping.config.db;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+import java.util.Map;
+
+/**
+ * Routes read-only queries to either the replica or master datasource
+ * based on the sticky-primary flag.
+ *
+ * When sticky is active (user just performed a write), reads go to master
+ * to ensure read-your-own-writes consistency.
+ * Otherwise, reads go to replica for load distribution.
+ */
+public class StickyAwareRoutingDataSource extends AbstractRoutingDataSource {
+
+	private static final String MASTER = "MASTER";
+	private static final String REPLICA = "REPLICA";
+
+	public StickyAwareRoutingDataSource(DataSource masterDataSource, DataSource replicaDataSource) {
+		Map<Object, Object> targetDataSources = Map.of(
+				MASTER, masterDataSource,
+				REPLICA, replicaDataSource
+		);
+		setTargetDataSources(targetDataSources);
+		setDefaultTargetDataSource(replicaDataSource);
+		afterPropertiesSet();
+	}
+
+	@Override
+	protected Object determineCurrentLookupKey() {
+		if (StickyPrimaryHolder.isSticky()) {
+			return MASTER;
+		}
+		return REPLICA;
+	}
+}

--- a/src/main/java/com/example/popping/config/db/StickyPrimaryAspect.java
+++ b/src/main/java/com/example/popping/config/db/StickyPrimaryAspect.java
@@ -1,0 +1,77 @@
+package com.example.popping.config.db;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Registers a TransactionSynchronization callback inside a write transaction.
+ * When the transaction commits successfully, the afterCommit callback sets the STICKY_PRIMARY cookie
+ * so subsequent requests from the same client read from master for a brief window.
+ *
+ * Order is set to LOWEST_PRECEDENCE to ensure this runs INSIDE the transaction proxy
+ * (transaction interceptor has default order = LOWEST_PRECEDENCE, lower order runs first/outside).
+ */
+@Aspect
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class StickyPrimaryAspect {
+
+	private static final String COOKIE_NAME = "STICKY_PRIMARY";
+	private static final int STICKY_DURATION_SECONDS = 3;
+
+	@Before("@within(org.springframework.transaction.annotation.Transactional) "
+			+ "&& !@annotation(org.springframework.transaction.annotation.Transactional)")
+	public void beforeClassLevelWriteTransaction() {
+		if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+			return;
+		}
+		registerStickyCallback();
+	}
+
+	@Before("@annotation(tx)")
+	public void beforeMethodLevelWriteTransaction(org.springframework.transaction.annotation.Transactional tx) {
+		if (tx.readOnly()) {
+			return;
+		}
+		registerStickyCallback();
+	}
+
+	private void registerStickyCallback() {
+		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+			return;
+		}
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				setStickyPrimaryCookie();
+			}
+		});
+	}
+
+	private void setStickyPrimaryCookie() {
+		ServletRequestAttributes attrs =
+				(ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+		if (attrs == null) {
+			return;
+		}
+		HttpServletResponse response = attrs.getResponse();
+		if (response == null) {
+			return;
+		}
+		Cookie cookie = new Cookie(COOKIE_NAME, "1");
+		cookie.setPath("/");
+		cookie.setMaxAge(STICKY_DURATION_SECONDS);
+		cookie.setHttpOnly(true);
+		response.addCookie(cookie);
+	}
+}

--- a/src/main/java/com/example/popping/config/db/StickyPrimaryAspect.java
+++ b/src/main/java/com/example/popping/config/db/StickyPrimaryAspect.java
@@ -2,6 +2,7 @@ package com.example.popping.config.db;
 
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -28,6 +29,9 @@ public class StickyPrimaryAspect {
 
 	private static final String COOKIE_NAME = "STICKY_PRIMARY";
 	private static final int STICKY_DURATION_SECONDS = 3;
+
+	@Value("${guest.identifier.secure-cookie:false}")
+	private boolean secureCookie;
 
 	@Before("@within(org.springframework.transaction.annotation.Transactional) "
 			+ "&& !@annotation(org.springframework.transaction.annotation.Transactional)")
@@ -72,6 +76,7 @@ public class StickyPrimaryAspect {
 		cookie.setPath("/");
 		cookie.setMaxAge(STICKY_DURATION_SECONDS);
 		cookie.setHttpOnly(true);
+		cookie.setSecure(secureCookie);
 		response.addCookie(cookie);
 	}
 }

--- a/src/main/java/com/example/popping/config/db/StickyPrimaryHolder.java
+++ b/src/main/java/com/example/popping/config/db/StickyPrimaryHolder.java
@@ -1,0 +1,26 @@
+package com.example.popping.config.db;
+
+/**
+ * ThreadLocal holder for sticky-primary flag.
+ * When set to true, read-only queries are routed to the master (write) datasource
+ * to guarantee read-your-own-writes consistency.
+ */
+public final class StickyPrimaryHolder {
+
+	private static final ThreadLocal<Boolean> STICKY = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+	private StickyPrimaryHolder() {
+	}
+
+	public static boolean isSticky() {
+		return STICKY.get();
+	}
+
+	public static void markSticky() {
+		STICKY.set(Boolean.TRUE);
+	}
+
+	public static void clear() {
+		STICKY.remove();
+	}
+}

--- a/src/main/java/com/example/popping/filter/StickyPrimaryFilter.java
+++ b/src/main/java/com/example/popping/filter/StickyPrimaryFilter.java
@@ -1,0 +1,47 @@
+package com.example.popping.filter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.example.popping.config.db.StickyPrimaryHolder;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Reads the sticky-primary cookie at request start and sets the ThreadLocal flag.
+ * Clears the ThreadLocal in finally to prevent leakage to the next request on the same thread.
+ */
+@Component
+public class StickyPrimaryFilter extends OncePerRequestFilter {
+
+	static final String COOKIE_NAME = "STICKY_PRIMARY";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+			FilterChain filterChain) throws ServletException, IOException {
+		try {
+			if (hasStickyPrimaryCookie(request)) {
+				StickyPrimaryHolder.markSticky();
+			}
+			filterChain.doFilter(request, response);
+		} finally {
+			StickyPrimaryHolder.clear();
+		}
+	}
+
+	private boolean hasStickyPrimaryCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return false;
+		}
+		return Arrays.stream(cookies)
+				.anyMatch(c -> COOKIE_NAME.equals(c.getName()) && "1".equals(c.getValue()));
+	}
+}

--- a/src/test/java/com/example/popping/config/db/StickyAwareRoutingDataSourceTest.java
+++ b/src/test/java/com/example/popping/config/db/StickyAwareRoutingDataSourceTest.java
@@ -1,0 +1,62 @@
+package com.example.popping.config.db;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StickyAwareRoutingDataSourceTest {
+
+	@Mock
+	private DataSource masterDataSource;
+
+	@Mock
+	private DataSource replicaDataSource;
+
+	@Mock
+	private Connection masterConnection;
+
+	@Mock
+	private Connection replicaConnection;
+
+	private StickyAwareRoutingDataSource routingDataSource;
+
+	@BeforeEach
+	void setUp() {
+		routingDataSource = new StickyAwareRoutingDataSource(masterDataSource, replicaDataSource);
+	}
+
+	@AfterEach
+	void tearDown() {
+		StickyPrimaryHolder.clear();
+	}
+
+	@Test
+	@DisplayName("routes to replica when not sticky")
+	void routesToReplicaByDefault() throws SQLException {
+		when(replicaDataSource.getConnection()).thenReturn(replicaConnection);
+		routingDataSource.getConnection();
+		verify(replicaDataSource).getConnection();
+	}
+
+	@Test
+	@DisplayName("routes to master when sticky flag is set")
+	void routesToMasterWhenSticky() throws SQLException {
+		when(masterDataSource.getConnection()).thenReturn(masterConnection);
+		StickyPrimaryHolder.markSticky();
+		routingDataSource.getConnection();
+		verify(masterDataSource).getConnection();
+	}
+}

--- a/src/test/java/com/example/popping/config/db/StickyPrimaryHolderTest.java
+++ b/src/test/java/com/example/popping/config/db/StickyPrimaryHolderTest.java
@@ -1,0 +1,52 @@
+package com.example.popping.config.db;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StickyPrimaryHolderTest {
+
+	@AfterEach
+	void tearDown() {
+		StickyPrimaryHolder.clear();
+	}
+
+	@Test
+	@DisplayName("default state is not sticky")
+	void defaultIsNotSticky() {
+		assertThat(StickyPrimaryHolder.isSticky()).isFalse();
+	}
+
+	@Test
+	@DisplayName("markSticky sets flag to true")
+	void markStickySetsFlag() {
+		StickyPrimaryHolder.markSticky();
+		assertThat(StickyPrimaryHolder.isSticky()).isTrue();
+	}
+
+	@Test
+	@DisplayName("clear resets flag to false")
+	void clearResetsFlag() {
+		StickyPrimaryHolder.markSticky();
+		StickyPrimaryHolder.clear();
+		assertThat(StickyPrimaryHolder.isSticky()).isFalse();
+	}
+
+	@Test
+	@DisplayName("ThreadLocal is isolated between threads")
+	void threadIsolation() throws InterruptedException {
+		StickyPrimaryHolder.markSticky();
+
+		boolean[] otherThreadSticky = {true};
+		Thread otherThread = new Thread(() -> {
+			otherThreadSticky[0] = StickyPrimaryHolder.isSticky();
+		});
+		otherThread.start();
+		otherThread.join();
+
+		assertThat(otherThreadSticky[0]).isFalse();
+		assertThat(StickyPrimaryHolder.isSticky()).isTrue();
+	}
+}

--- a/src/test/java/com/example/popping/filter/StickyPrimaryFilterTest.java
+++ b/src/test/java/com/example/popping/filter/StickyPrimaryFilterTest.java
@@ -1,0 +1,75 @@
+package com.example.popping.filter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.example.popping.config.db.StickyPrimaryHolder;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+class StickyPrimaryFilterTest {
+
+	private final StickyPrimaryFilter filter = new StickyPrimaryFilter();
+
+	@Test
+	@DisplayName("sets sticky flag when STICKY_PRIMARY cookie is present")
+	void setsSticky() throws ServletException, IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("STICKY_PRIMARY", "1"));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean[] stickyDuringFilter = {false};
+		FilterChain chain = (req, res) -> {
+			stickyDuringFilter[0] = StickyPrimaryHolder.isSticky();
+		};
+
+		filter.doFilterInternal(request, response, chain);
+
+		assertThat(stickyDuringFilter[0]).isTrue();
+		assertThat(StickyPrimaryHolder.isSticky()).isFalse();
+	}
+
+	@Test
+	@DisplayName("does not set sticky flag when cookie is absent")
+	void doesNotSetSticky() throws ServletException, IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean[] stickyDuringFilter = {true};
+		FilterChain chain = (req, res) -> {
+			stickyDuringFilter[0] = StickyPrimaryHolder.isSticky();
+		};
+
+		filter.doFilterInternal(request, response, chain);
+
+		assertThat(stickyDuringFilter[0]).isFalse();
+	}
+
+	@Test
+	@DisplayName("clears ThreadLocal even if chain throws exception")
+	void clearsOnException() throws ServletException, IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("STICKY_PRIMARY", "1"));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		FilterChain chain = mock(FilterChain.class);
+		doThrow(new RuntimeException("simulated error")).when(chain).doFilter(request, response);
+
+		try {
+			filter.doFilterInternal(request, response, chain);
+		} catch (RuntimeException ignored) {
+		}
+
+		assertThat(StickyPrimaryHolder.isSticky()).isFalse();
+	}
+}


### PR DESCRIPTION
## Summary
- 쓰기 트랜잭션 커밋 후 STICKY_PRIMARY 쿠키(3초)를 발급하여 Read-your-own-writes 정합성 보장
- StickyAwareRoutingDataSource가 LazyConnectionDataSourceProxy의 readOnlyDataSource로 동작하며, sticky 시 Master로 라우팅
- TransactionSynchronization.afterCommit으로 커밋 성공 시에만 쿠키 발급 (롤백 시 미발급)
- spring-boot-starter-aop 의존성 추가

## 부하테스트 결과 (1000 vusers, 10분)
| 지표 | Before | After | 변화 |
|---|---|---|---|
| Replication Lag 평균 | 66s | 6s | -91% |
| Replication Lag 최대 | 150s | 27s | -82% |
| P99 응답시간 | 366ms | 153ms | -58% |

## Test plan
- [x] StickyPrimaryHolderTest — ThreadLocal 격리, mark/clear 동작
- [x] StickyAwareRoutingDataSourceTest — sticky 시 Master, 아닐 때 Replica 라우팅
- [x] StickyPrimaryFilterTest — 쿠키 읽기, ThreadLocal 정리, 예외 시에도 clear

Closes #124
