### PR TITLE
refactor: merge 3-pass comment enrichment into single pass

### DIFF
--- a/src/main/java/com/example/popping/service/CommentService.java
+++ b/src/main/java/com/example/popping/service/CommentService.java
@@ -129,11 +129,7 @@ public class CommentService {
                 ? getFirstPageCommon(postId)
                 : buildCommentPage(postId, page);
 
-        if (page == 0) {
-            base = mergeLikeCounts(base);
-        }
-
-        return mergePersonalReaction(base, principal, resolveGuestIdentifier(guestIdentifier));
+        return enrichComments(base, page == 0, principal, resolveGuestIdentifier(guestIdentifier));
     }
 
     private String resolveGuestIdentifier(String raw) {
@@ -225,22 +221,34 @@ public class CommentService {
                 .toList();
     }
 
-    private CommentPageResponse mergeLikeCounts(CommentPageResponse page) {
+    private CommentPageResponse enrichComments(CommentPageResponse page,
+                                               boolean refreshLikeCounts,
+                                               UserPrincipal principal,
+                                               String guestIdentifier) {
         if (page == null || page.comments().isEmpty()) return page;
+        if (!refreshLikeCounts && principal == null
+                && (guestIdentifier == null || guestIdentifier.isBlank())) {
+            return page;
+        }
 
         Set<Long> commentIds = new LinkedHashSet<>();
         collectCommentIds(page.comments(), commentIds);
 
-        Map<Long, CommentRepository.LikeCount> countMap = commentRepository.findLikeCountsByIds(commentIds)
-                .stream()
-                .collect(Collectors.toMap(CommentRepository.LikeCount::getId, c -> c));
+        Map<Long, CommentRepository.LikeCount> countMap = refreshLikeCounts
+                ? commentRepository.findLikeCountsByIds(commentIds).stream()
+                        .collect(Collectors.toMap(CommentRepository.LikeCount::getId, c -> c))
+                : Collections.emptyMap();
 
-        List<CommentResponse> updated = page.comments().stream()
-                .map(comment -> applyLikeCount(comment, countMap))
+        Map<Long, MyReactionView> reactionMap = buildReactionMap(commentIds, principal, guestIdentifier);
+
+        if (countMap.isEmpty() && reactionMap.isEmpty()) return page;
+
+        List<CommentResponse> enriched = page.comments().stream()
+                .map(comment -> applyMetadata(comment, countMap, reactionMap))
                 .toList();
 
         return new CommentPageResponse(
-                updated,
+                enriched,
                 page.totalComments(),
                 page.currentPage(),
                 page.totalPages(),
@@ -249,13 +257,35 @@ public class CommentService {
         );
     }
 
-    private CommentResponse applyLikeCount(CommentResponse comment, Map<Long, CommentRepository.LikeCount> countMap) {
+    private Map<Long, MyReactionView> buildReactionMap(Set<Long> commentIds,
+                                                        UserPrincipal principal,
+                                                        String guestIdentifier) {
+        if (principal == null && (guestIdentifier == null || guestIdentifier.isBlank())) {
+            return Collections.emptyMap();
+        }
+
+        String targetType = Like.TargetType.COMMENT.name();
+        List<MyReactionView> reactions = (principal != null)
+                ? likeRepository.findReactionForMember(commentIds, targetType, principal.getUserId())
+                : likeRepository.findReactionForGuest(commentIds, targetType, guestIdentifier);
+
+        return reactions.stream()
+                .collect(Collectors.toMap(MyReactionView::getTargetId, r -> r));
+    }
+
+    private CommentResponse applyMetadata(CommentResponse comment,
+                                           Map<Long, CommentRepository.LikeCount> countMap,
+                                           Map<Long, MyReactionView> reactionMap) {
         CommentRepository.LikeCount counts = countMap.get(comment.id());
-        int likeCount    = counts != null ? counts.getLikeCount()    : comment.likeCount();
+        int likeCount = counts != null ? counts.getLikeCount() : comment.likeCount();
         int dislikeCount = counts != null ? counts.getDislikeCount() : comment.dislikeCount();
 
-        List<CommentResponse> updatedChildren = comment.children().stream()
-                .map(child -> applyLikeCount(child, countMap))
+        MyReactionView reaction = reactionMap.get(comment.id());
+        boolean likedByMe = reaction != null && reaction.getLikedByMe() == 1;
+        boolean dislikedByMe = reaction != null && reaction.getDislikedByMe() == 1;
+
+        List<CommentResponse> enrichedChildren = comment.children().stream()
+                .map(child -> applyMetadata(child, countMap, reactionMap))
                 .toList();
 
         return new CommentResponse(
@@ -266,69 +296,11 @@ public class CommentService {
                 comment.guestNickname(),
                 likeCount,
                 dislikeCount,
-                comment.likedByMe(),
-                comment.dislikedByMe(),
-                comment.parentId(),
-                comment.depth(),
-                updatedChildren
-        );
-    }
-
-    private CommentPageResponse mergePersonalReaction(CommentPageResponse page,
-                                                     UserPrincipal principal,
-                                                     String guestIdentifier) {
-        if (page == null || page.comments().isEmpty()) return page;
-        if (principal == null && (guestIdentifier == null || guestIdentifier.isBlank())) return page;
-
-        Set<Long> commentIds = new LinkedHashSet<>();
-        collectCommentIds(page.comments(), commentIds);
-
-        String targetType = Like.TargetType.COMMENT.name();
-        List<MyReactionView> myReactionViews = (principal != null)
-                ? likeRepository.findReactionForMember(commentIds, targetType, principal.getUserId())
-                : likeRepository.findReactionForGuest(commentIds, targetType, guestIdentifier);
-
-        Map<Long, MyReactionView> myReactionViewMap = myReactionViews.stream()
-                .collect(Collectors.toMap(MyReactionView::getTargetId, s -> s));
-
-        List<CommentResponse> merged = page.comments().stream()
-                .map(comment -> applyPersonalReaction(comment, myReactionViewMap))
-                .toList();
-
-        return new CommentPageResponse(
-                merged,
-                page.totalComments(),
-                page.currentPage(),
-                page.totalPages(),
-                page.hasNext(),
-                page.hasPrevious()
-        );
-    }
-
-    private CommentResponse applyPersonalReaction(CommentResponse comment,
-                                                  Map<Long, MyReactionView> myReactionViewMap) {
-        MyReactionView s = myReactionViewMap.get(comment.id());
-
-        boolean likedByMe    = s != null && s.getLikedByMe()    == 1;
-        boolean dislikedByMe = s != null && s.getDislikedByMe() == 1;
-
-        List<CommentResponse> mergedChildren = comment.children().stream()
-                .map(child -> applyPersonalReaction(child, myReactionViewMap))
-                .toList();
-
-        return new CommentResponse(
-                comment.id(),
-                comment.content(),
-                comment.authorName(),
-                comment.authorId(),
-                comment.guestNickname(),
-                comment.likeCount(),
-                comment.dislikeCount(),
                 likedByMe,
                 dislikedByMe,
                 comment.parentId(),
                 comment.depth(),
-                mergedChildren
+                enrichedChildren
         );
     }
 

--- a/src/test/java/com/example/popping/service/CommentServiceTest.java
+++ b/src/test/java/com/example/popping/service/CommentServiceTest.java
@@ -529,7 +529,7 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("댓글 페이지 조회(page>0, 비로그인): enrichment를 전부 건너뛰고 CTE 값 그대로 반환한다")
+    @DisplayName("댓글 페이지 조회(page>0, 미식별 사용자): principal과 guestIdentifier 모두 없으면 enrichment를 건너뛰고 CTE 값 그대로 반환한다")
     void getCommentPage_pageGreaterThanZero_noAuth_skipsAllEnrichment() {
 
         // given

--- a/src/test/java/com/example/popping/service/CommentServiceTest.java
+++ b/src/test/java/com/example/popping/service/CommentServiceTest.java
@@ -529,6 +529,84 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("댓글 페이지 조회(page>0, 비로그인): enrichment를 전부 건너뛰고 CTE 값 그대로 반환한다")
+    void getCommentPage_pageGreaterThanZero_noAuth_skipsAllEnrichment() {
+
+        // given
+        Long postId = 10L;
+        int page = 1;
+
+        Post post = mock(Post.class);
+        when(postService.getPost(postId)).thenReturn(post);
+        when(post.getCommentCount()).thenReturn(150);
+
+        CommentTreeRowView r1 = rowView(101L, null, "page1 comment", 0, 100L, null, 7, 2);
+        when(commentRepository.findPagedCommentTree(postId, CommentService.COMMENTS_SIZE, 100))
+                .thenReturn(List.of(r1));
+        when(userService.getUserIdToNicknameMap(Set.of(100L)))
+                .thenReturn(Map.of(100L, "nick"));
+
+        // when
+        CommentPageResponse res = commentService.getCommentPage(postId, page, null, null);
+
+        // then — no enrichment queries fired
+        verify(commentRepository, never()).findLikeCountsByIds(any());
+        verify(likeRepository, never()).findReactionForMember(any(), any(), any());
+        verify(likeRepository, never()).findReactionForGuest(any(), any(), any());
+
+        // CTE values preserved
+        CommentResponse comment = res.comments().get(0);
+        assertEquals(7, comment.likeCount());
+        assertEquals(2, comment.dislikeCount());
+        assertFalse(comment.likedByMe());
+        assertFalse(comment.dislikedByMe());
+
+        // page metadata
+        assertEquals(1, res.currentPage());
+        assertTrue(res.hasPrevious());
+        assertFalse(res.hasNext());
+    }
+
+    @Test
+    @DisplayName("댓글 페이지 조회(page>0, 회원): reaction만 적용하고 likeCount는 갱신하지 않는다")
+    void getCommentPage_pageGreaterThanZero_member_reactionOnlyNoLikeCountRefresh() {
+
+        // given
+        Long postId = 10L;
+        int page = 1;
+        UserPrincipal principal = principal(42L);
+
+        Post post = mock(Post.class);
+        when(postService.getPost(postId)).thenReturn(post);
+        when(post.getCommentCount()).thenReturn(150);
+
+        CommentTreeRowView r1 = rowView(101L, null, "page1", 0, 100L, null, 5, 1);
+        when(commentRepository.findPagedCommentTree(postId, CommentService.COMMENTS_SIZE, 100))
+                .thenReturn(List.of(r1));
+        when(userService.getUserIdToNicknameMap(Set.of(100L)))
+                .thenReturn(Map.of(100L, "nick"));
+
+        MyReactionView rv = myReaction(101L, 0, 1);
+        when(likeRepository.findReactionForMember(anyCollection(), any(), eq(42L)))
+                .thenReturn(List.of(rv));
+
+        // when
+        CommentPageResponse res = commentService.getCommentPage(postId, page, principal, null);
+
+        // then — likeCount refresh NOT called (page > 0)
+        verify(commentRepository, never()).findLikeCountsByIds(any());
+
+        // reaction IS applied
+        verify(likeRepository).findReactionForMember(anyCollection(), any(), eq(42L));
+
+        CommentResponse comment = res.comments().get(0);
+        assertEquals(5, comment.likeCount());    // CTE value kept (no refresh)
+        assertEquals(1, comment.dislikeCount()); // CTE value kept
+        assertFalse(comment.likedByMe());
+        assertTrue(comment.dislikedByMe());      // reaction applied
+    }
+
+    @Test
     @DisplayName("댓글 조회: 없으면 COMMENT_NOT_FOUND 예외를 던진다")
     void getComment_fail_notFound() {
 


### PR DESCRIPTION
## Summary
- 댓글 조회 시 3회 트리 순회(buildTree → mergeLikeCounts → mergePersonalReaction)를 2회로 통합
- ID 수집 1회 → likeCount + reaction 맵 동시 구성 → 단일 `applyMetadata` 재귀 순회로 병합
- 댓글 100개 기준 임시 객체 생성 300개 → 200개로 감소
- 미식별 사용자(principal=null, guestIdentifier=null) + page > 0일 때 enrichment 전체 스킵
  - 비로그인이라도 게스트 쿠키가 있으면 reaction 조회는 수행

Closes #126

## Test plan
- [x] 댓글 첫 페이지(page=0) 조회 시 likeCount 실시간 반영 확인
- [x] 로그인 회원의 likedByMe/dislikedByMe 정상 표시
- [x] 게스트 사용자의 reaction 정상 표시
- [x] 미식별 사용자(principal=null, guestIdentifier=null) + page > 0 조회 시 enrichment 쿼리 없이 즉시 반환
- [x] page > 0 + 로그인 회원: reaction만 적용, likeCount는 갱신하지 않음 확인
- [x] 대댓글(depth > 0) children에도 metadata 정상 적용
- [x] 기존 단위 테스트 전체 통과 (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)