### PR TITLE
fix: 좋아요 방송 payload를 delta → 절대 카운트로 교체

### DIFF
--- a/src/main/java/com/example/popping/dto/LikeResponse.java
+++ b/src/main/java/com/example/popping/dto/LikeResponse.java
@@ -2,10 +2,23 @@ package com.example.popping.dto;
 
 import com.example.popping.domain.Like;
 
+/**
+ * Broadcast payload for a like/dislike change.
+ *
+ * <p>Carries the <b>absolute</b> counters rather than a delta. STOMP does not guarantee
+ * exactly-once delivery, and a request may be a no-op (liking something already liked),
+ * so an increment-based payload drifts away from the database permanently. Clients must
+ * assign these values, never add to their current ones.
+ *
+ * <p>{@code action} describes what the requester asked for; it is not a signal that the
+ * database actually changed. Use the counters for display state.
+ */
 public record LikeResponse(
         Long targetId,
         Like.TargetType targetType,
-        LikeAction action
+        LikeAction action,
+        int likeCount,
+        int dislikeCount
 ) {
     public enum LikeAction {
         LIKED,

--- a/src/main/java/com/example/popping/repository/CommentRepository.java
+++ b/src/main/java/com/example/popping/repository/CommentRepository.java
@@ -25,6 +25,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
            "FROM Comment c WHERE c.id IN :ids")
     List<LikeCount> findLikeCountsByIds(@Param("ids") Collection<Long> ids);
 
+    @Query("SELECT c.likeCount AS likeCount, c.dislikeCount AS dislikeCount FROM Comment c WHERE c.id = :commentId")
+    LikeCountView findLikeCountsById(@Param("commentId") Long commentId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Comment c SET c.likeCount = c.likeCount + :delta WHERE c.id = :commentId")
     int updateLikeCount(@Param("commentId") Long commentId, @Param("delta") int delta);

--- a/src/main/java/com/example/popping/repository/LikeCountView.java
+++ b/src/main/java/com/example/popping/repository/LikeCountView.java
@@ -1,0 +1,11 @@
+package com.example.popping.repository;
+
+/**
+ * Current like/dislike counters of a single target, read back after a delta is applied
+ * so that broadcasts can carry absolute state instead of an increment.
+ */
+public interface LikeCountView {
+	int getLikeCount();
+
+	int getDislikeCount();
+}

--- a/src/main/java/com/example/popping/repository/LikeRepository.java
+++ b/src/main/java/com/example/popping/repository/LikeRepository.java
@@ -46,13 +46,26 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     long countByTargetIdAndTargetTypeAndTypeAndUser_Id(
             Long targetId, Like.TargetType targetType, Like.Type type, Long userId);
 
+    /**
+     * Inserts a like row, treating an existing row as a no-op.
+     *
+     * <p>Uses {@code ON DUPLICATE KEY UPDATE id = id} rather than {@code INSERT IGNORE}:
+     * {@code INSERT IGNORE} downgrades every error to a warning (truncation, NOT NULL,
+     * FK violations), not just duplicate keys.
+     *
+     * <p><b>Returns affected rows: 1 when inserted, 0 when the row already existed.</b>
+     * The zero-on-duplicate contract depends on the JDBC URL setting
+     * {@code useAffectedRows=true}. Without it Connector/J enables {@code CLIENT_FOUND_ROWS},
+     * which reports <em>found</em> rows instead of <em>changed</em> rows, so a duplicate
+     * would return 1 and callers would double-count. See {@code LikeConcurrencyTest}.
+     */
     @Modifying
     @Query(value = """
     insert into likes (target_type, target_id, type, user_id, guest_identifier)
     values (:targetType, :targetId, :type, :userId, :guestIdentifier)
     on duplicate key update id = id
     """, nativeQuery = true)
-    int insertIgnore(
+    int upsertLike(
             @Param("targetType") String targetType,
             @Param("targetId") Long targetId,
             @Param("type") String type,

--- a/src/main/java/com/example/popping/repository/PostRepository.java
+++ b/src/main/java/com/example/popping/repository/PostRepository.java
@@ -35,6 +35,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("UPDATE Post p SET p.viewCount = p.viewCount + :delta WHERE p.id = :postId")
     void increaseViewCountBy(@Param("postId") Long postId, @Param("delta") long delta);
 
+    @Query("SELECT p.likeCount AS likeCount, p.dislikeCount AS dislikeCount FROM Post p WHERE p.id = :postId")
+    LikeCountView findLikeCountsById(@Param("postId") Long postId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Post p SET p.likeCount = p.likeCount + :delta WHERE p.id = :postId")
     void updateLikeCount(@Param("postId") Long postId, @Param("delta") int delta);

--- a/src/main/java/com/example/popping/service/CommentService.java
+++ b/src/main/java/com/example/popping/service/CommentService.java
@@ -23,6 +23,7 @@ import com.example.popping.dto.MemberCommentCreateRequest;
 import com.example.popping.exception.CustomAppException;
 import com.example.popping.exception.ErrorType;
 import com.example.popping.repository.CommentRepository;
+import com.example.popping.repository.LikeCountView;
 import com.example.popping.repository.MyReactionView;
 import com.example.popping.repository.CommentTreeRowView;
 import com.example.popping.repository.LikeRepository;
@@ -121,6 +122,14 @@ public class CommentService {
 
     public void updateDislikeCount(Long targetId, int delta) {
         commentRepository.updateDislikeCount(targetId, delta);
+    }
+
+    public LikeCountView getLikeCounts(Long targetId) {
+        LikeCountView counts = commentRepository.findLikeCountsById(targetId);
+        if (counts == null) {
+            throw new CustomAppException(ErrorType.COMMENT_NOT_FOUND);
+        }
+        return counts;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/popping/service/LikeService.java
+++ b/src/main/java/com/example/popping/service/LikeService.java
@@ -11,6 +11,7 @@ import com.example.popping.dto.LikeRequest;
 import com.example.popping.dto.LikeResponse;
 import com.example.popping.exception.CustomAppException;
 import com.example.popping.exception.ErrorType;
+import com.example.popping.repository.LikeCountView;
 import com.example.popping.repository.LikeRepository;
 
 @Service
@@ -29,7 +30,7 @@ public class LikeService {
         String guestIdentifier = resolveGuestIdentifier(req.guestIdentifier());
         validateActor(user, guestIdentifier);
 
-        int inserted = likeRepository.insertIgnore(
+        int inserted = likeRepository.upsertLike(
                 req.targetType().name(),
                 req.targetId(),
                 req.type().name(),
@@ -41,7 +42,7 @@ public class LikeService {
             applyDelta(req.targetType(), req.type(), req.targetId(), 1);
         }
 
-        return new LikeResponse(req.targetId(), req.targetType(), addedAction(req.type()));
+        return buildResponse(req, addedAction(req.type()));
     }
 
     public LikeResponse removeLike(LikeRequest req, UserPrincipal principal) {
@@ -61,7 +62,30 @@ public class LikeService {
             applyDelta(req.targetType(), req.type(), req.targetId(), -1);
         }
 
-        return new LikeResponse(req.targetId(), req.targetType(), removedAction(req.type()));
+        return buildResponse(req, removedAction(req.type()));
+    }
+
+    /**
+     * Reads the counters back after the delta so the broadcast carries absolute state.
+     * A no-op request therefore reports the unchanged counts instead of implying a change.
+     */
+    private LikeResponse buildResponse(LikeRequest req, LikeResponse.LikeAction action) {
+        LikeCountView counts = readCounts(req.targetType(), req.targetId());
+        return new LikeResponse(
+                req.targetId(),
+                req.targetType(),
+                action,
+                counts.getLikeCount(),
+                counts.getDislikeCount()
+        );
+    }
+
+    private LikeCountView readCounts(Like.TargetType targetType, Long targetId) {
+        return switch (targetType) {
+            case POST -> postService.getLikeCounts(targetId);
+            case COMMENT -> commentService.getLikeCounts(targetId);
+            default -> throw new CustomAppException(ErrorType.INVALID_TARGET_TYPE);
+        };
     }
 
     private User getUser(UserPrincipal principal) {

--- a/src/main/java/com/example/popping/service/PostService.java
+++ b/src/main/java/com/example/popping/service/PostService.java
@@ -22,6 +22,7 @@ import com.example.popping.dto.*;
 import com.example.popping.event.CacheEvictEvent;
 import com.example.popping.exception.CustomAppException;
 import com.example.popping.exception.ErrorType;
+import com.example.popping.repository.LikeCountView;
 import com.example.popping.repository.LikeRepository;
 import com.example.popping.repository.PostRepository;
 import com.example.popping.repository.MyReactionView;
@@ -144,6 +145,14 @@ public class PostService {
 
     public void updateDislikeCount(Long targetId, int delta) {
         postRepository.updateDislikeCount(targetId, delta);
+    }
+
+    public LikeCountView getLikeCounts(Long targetId) {
+        LikeCountView counts = postRepository.findLikeCountsById(targetId);
+        if (counts == null) {
+            throw new CustomAppException(ErrorType.POST_NOT_FOUND);
+        }
+        return counts;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/post/detail.html
+++ b/src/main/resources/templates/post/detail.html
@@ -664,7 +664,6 @@
     function updateReaction(response) {
         const targetType = response.targetType.toLowerCase();
         const targetId = response.targetId;
-        const action = response.action;
 
         const likeCountElement = document.getElementById(`like-count-${targetType}-${targetId}`);
         const dislikeCountElement = document.getElementById(`dislike-count-${targetType}-${targetId}`);
@@ -673,23 +672,11 @@
             return;
         }
 
-        let likeCount = parseInt(likeCountElement.textContent, 10);
-        let dislikeCount = parseInt(dislikeCountElement.textContent, 10);
-
-        switch (action) {
-            case 'LIKED':
-                likeCountElement.textContent = likeCount + 1;
-                break;
-            case 'UNLIKED':
-                likeCountElement.textContent = Math.max(0, likeCount - 1);
-                break;
-            case 'DISLIKED':
-                dislikeCountElement.textContent = dislikeCount + 1;
-                break;
-            case 'UNDISLIKED':
-                dislikeCountElement.textContent = Math.max(0, dislikeCount - 1);
-                break;
-        }
+        // Assign the absolute counts the server sent; never increment.
+        // The broadcast can arrive more than once, or describe a request that was a no-op
+        // (liking something already liked), so incrementing drifts away from the database.
+        likeCountElement.textContent = response.likeCount;
+        dislikeCountElement.textContent = response.dislikeCount;
     }
 
     function getGuestIdentifier() {

--- a/src/test/java/com/example/popping/service/LikeServiceTest.java
+++ b/src/test/java/com/example/popping/service/LikeServiceTest.java
@@ -14,6 +14,7 @@ import com.example.popping.dto.LikeRequest;
 import com.example.popping.dto.LikeResponse;
 import com.example.popping.exception.CustomAppException;
 import com.example.popping.exception.ErrorType;
+import com.example.popping.repository.LikeCountView;
 import com.example.popping.repository.LikeRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,8 +44,9 @@ class LikeServiceTest {
         when(userService.getLoginUserById(1L)).thenReturn(user);
         when(user.getId()).thenReturn(1L);
 
-        when(likeRepository.insertIgnore("POST", 10L, "LIKE", 1L, null))
+        when(likeRepository.upsertLike("POST", 10L, "LIKE", 1L, null))
                 .thenReturn(1);
+        when(postService.getLikeCounts(10L)).thenReturn(counts(6, 2));
 
         // when
         LikeResponse res = likeService.addLike(req, principal);
@@ -54,6 +56,8 @@ class LikeServiceTest {
         verify(postService, never()).updateDislikeCount(anyLong(), anyInt());
 
         assertEquals(LikeResponse.LikeAction.LIKED, res.action());
+        assertEquals(6, res.likeCount());
+        assertEquals(2, res.dislikeCount());
     }
 
     @Test
@@ -63,8 +67,9 @@ class LikeServiceTest {
         // given
         LikeRequest req = new LikeRequest(10L, Like.TargetType.POST, Like.Type.LIKE, "guest-1");
 
-        when(likeRepository.insertIgnore("POST", 10L, "LIKE", null, "guest-1"))
+        when(likeRepository.upsertLike("POST", 10L, "LIKE", null, "guest-1"))
                 .thenReturn(0);
+        when(postService.getLikeCounts(10L)).thenReturn(counts(5, 2));
 
         // when
         LikeResponse res = likeService.addLike(req, null);
@@ -72,6 +77,47 @@ class LikeServiceTest {
         // then
         verify(postService, never()).updateLikeCount(anyLong(), anyInt());
         assertEquals(LikeResponse.LikeAction.LIKED, res.action());
+    }
+
+    @Test
+    @DisplayName("중복 좋아요: 응답이 DB의 현재 카운트를 그대로 실어 화면 드리프트를 막는다")
+    void addLike_duplicate_reportsUnchangedAbsoluteCounts() {
+
+        // given — DB already holds this like, so the row insert is a no-op
+        LikeRequest req = new LikeRequest(10L, Like.TargetType.POST, Like.Type.LIKE, "guest-1");
+
+        when(likeRepository.upsertLike("POST", 10L, "LIKE", null, "guest-1"))
+                .thenReturn(0);
+        when(postService.getLikeCounts(10L)).thenReturn(counts(5, 2));
+
+        // when
+        LikeResponse res = likeService.addLike(req, null);
+
+        // then — the payload must be the unchanged DB state, not an implied increment.
+        // Clients assign these values, so a duplicate request leaves the display untouched.
+        assertEquals(5, res.likeCount());
+        assertEquals(2, res.dislikeCount());
+        verify(postService, never()).updateLikeCount(anyLong(), anyInt());
+    }
+
+    @Test
+    @DisplayName("중복 취소: 응답이 DB의 현재 카운트를 그대로 실어 화면 드리프트를 막는다")
+    void removeLike_duplicate_reportsUnchangedAbsoluteCounts() {
+
+        // given — nothing to delete, so the counters must not move
+        LikeRequest req = new LikeRequest(20L, Like.TargetType.COMMENT, Like.Type.LIKE, "guest-1");
+
+        when(likeRepository.deleteByActor(Like.TargetType.COMMENT, 20L, Like.Type.LIKE, null, "guest-1"))
+                .thenReturn(0);
+        when(commentService.getLikeCounts(20L)).thenReturn(counts(3, 1));
+
+        // when
+        LikeResponse res = likeService.removeLike(req, null);
+
+        // then
+        assertEquals(3, res.likeCount());
+        assertEquals(1, res.dislikeCount());
+        verify(commentService, never()).updateLikeCount(anyLong(), anyInt());
     }
 
     @Test
@@ -87,6 +133,7 @@ class LikeServiceTest {
 
         when(likeRepository.deleteByActor(Like.TargetType.COMMENT, 20L, Like.Type.DISLIKE, user, null))
                 .thenReturn(1);
+        when(commentService.getLikeCounts(20L)).thenReturn(counts(3, 0));
 
         // when
         LikeResponse res = likeService.removeLike(req, principal);
@@ -96,6 +143,8 @@ class LikeServiceTest {
         verify(commentService, never()).updateLikeCount(anyLong(), anyInt());
 
         assertEquals(LikeResponse.LikeAction.UNDISLIKED, res.action());
+        assertEquals(3, res.likeCount());
+        assertEquals(0, res.dislikeCount());
     }
 
     @Test
@@ -107,6 +156,7 @@ class LikeServiceTest {
 
         when(likeRepository.deleteByActor(Like.TargetType.COMMENT, 20L, Like.Type.LIKE, null, "guest-1"))
                 .thenReturn(0);
+        when(commentService.getLikeCounts(20L)).thenReturn(counts(3, 1));
 
         // when
         LikeResponse res = likeService.removeLike(req, null);
@@ -138,6 +188,28 @@ class LikeServiceTest {
         assertEquals(ErrorType.ACCESS_DENIED, ex2.getErrorType());
     }
 
+    @Test
+    @DisplayName("대상이 사라진 경우: 카운트를 읽지 못하면 예외를 던져 롤백한다")
+    void addLike_fail_whenTargetMissing() {
+
+        // given
+        LikeRequest req = new LikeRequest(99L, Like.TargetType.POST, Like.Type.LIKE, "guest-1");
+
+        when(likeRepository.upsertLike("POST", 99L, "LIKE", null, "guest-1"))
+                .thenReturn(1);
+        when(postService.getLikeCounts(99L))
+                .thenThrow(new CustomAppException(ErrorType.POST_NOT_FOUND));
+
+        // when
+        CustomAppException ex = assertThrows(
+                CustomAppException.class,
+                () -> likeService.addLike(req, null)
+        );
+
+        // then
+        assertEquals(ErrorType.POST_NOT_FOUND, ex.getErrorType());
+    }
+
     private UserPrincipal principal(Long userId) {
         UserPrincipal p = mock(UserPrincipal.class);
         when(p.getUserId()).thenReturn(userId);
@@ -146,5 +218,19 @@ class LikeServiceTest {
 
     private User userAuthOnly() {
         return mock(User.class);
+    }
+
+    private static LikeCountView counts(int likeCount, int dislikeCount) {
+        return new LikeCountView() {
+            @Override
+            public int getLikeCount() {
+                return likeCount;
+            }
+
+            @Override
+            public int getDislikeCount() {
+                return dislikeCount;
+            }
+        };
     }
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #128 


## :bulb: 상세 내용: 

## Summary
  - **문제**: `LikeResponse`가 action enum(LIKED/UNLIKED/...)만 실어 보내고 브라우저가 로컬 카운트를 ±1 했음.
    중복·no-op 요청(이미 누른 좋아요 재클릭)이나 STOMP 중복 전달 시 화면이 DB와 영구히 어긋남.
    DB는 항상 정확했고 틀어진 건 화면뿐.
  - **해결**: delta 적용 직후 **같은 쓰기 트랜잭션 안에서** 카운트를 재조회해 절대값(`likeCount`/`dislikeCount`)을
    payload에 포함. 클라이언트는 증분 대신 대입만 한다. 같은 트랜잭션이라 replica 라우팅·복제 지연과 무관.
  - `LikeCountView` 프로젝션 추가 + `PostService`/`CommentService.getLikeCounts()` 
    (대상이 없으면 `POST_NOT_FOUND`/`COMMENT_NOT_FOUND`로 롤백)
  - `LikeRepository.insertIgnore` → `upsertLike` 리네임. 실제 쿼리는 `ON DUPLICATE KEY UPDATE`이며,
    0-on-duplicate 계약이 JDBC `useAffectedRows=true`에 의존한다는 점을 주석으로 명시
  - **비용**: add/remove 요청당 PK 단건 카운트 조회 1회 추가 (no-op 요청에도 발생)
  
  ## Known limitation (후속 예정) 
  대입 방식은 중복 전달에는 안전하지만 **역순 도착**에는 안전하지 않다. 동시 요청 두 건이 각각 11, 12를 읽고
  브로드캐스트가 `12 → 11` 순으로 도착하면 다음 이벤트나 새로고침 전까지 11로 표시된다. payload에 순서 토큰이
  없어 값만으로는 최신성을 판별할 수 없다(add/remove가 섞이면 대소 비교도 무의미).
  `reactionVersion` 원자 증가 필드로 후속 처리 예정.
  기존 버그(모든 no-op에서 항상, 영구)보다 발생 조건이 훨씬 좁고 자가 교정된다는 점에서 우선순위를 낮게 뒀다.
  
  ## Test plan 
  - [x] `LikeServiceTest` 8건 통과
  - [x] 신규 — 중복 좋아요/중복 취소 시 응답이 DB 현재 카운트 그대로 (증분 암시 없음)
  - [x] 신규 — 대상 소실 시 `POST_NOT_FOUND` 예외
  - [ ] 수동 — 브라우저 2개에서 실시간 반영 확인
  - [ ] 수동 — 이미 누른 좋아요 재클릭 시 화면 카운트 불변 확인