### PR TITLE
부하테스트가 정상 replica를 기다리다 스스로 중단하던 문제 수정

### DIFF
--- a/docs/load-test/measurement-protocol.md
+++ b/docs/load-test/measurement-protocol.md
@@ -127,7 +127,12 @@ bash docs/load-test/run-ab.sh stage1-after-2  stage1-svg-20260813
 
 arm 1회 = 워밍업 600초 + 복제 배출 대기 + 본 측정 600초 ≈ **27~45분**. 종료 코드는 0(사용 가능) / 1(셋업 실패) / 2(돌긴 했으나 비교 불가).
 
-환경 변수로 조절 가능: `WARMUP_SKIP=1`(이미 데워진 JVM 재사용), `WARMUP_MAX_PASSES`, `JIT_SETTLED_RATIO`, `LAG_WAIT_TRIES_POST_WARMUP`.
+환경 변수로 조절 가능: `WARMUP_SKIP=1`(이미 데워진 JVM 재사용), `WARMUP_MAX_PASSES`, `JIT_SETTLED_RATIO`, `LAG_WAIT_TRIES`, `LAG_WAIT_TRIES_POST_WARMUP`.
+
+**복제 지연 대기 예산은 두 지점 모두 기본 30분(`360 × 5초`)이다.** 워밍업 전 예산이 500초였을 때
+2026-08-16 실행에서 arm 2가 523초 만에 중단됐는데, 복제는 정상이었고 약 1분 뒤 GTID가 일치했다.
+**세션의 첫 arm만 지연 0에서 출발하고, 두 번째 이후는 직전 arm의 본 측정이 남긴 백로그에서 출발한다**
+— 이번 경우 1.85만 트랜잭션이었다. 연속 실행에서는 짧은 예산이 구조적으로 부족하다.
 
 ### 분석
 

--- a/docs/load-test/run-ab.sh
+++ b/docs/load-test/run-ab.sh
@@ -62,9 +62,14 @@ WARMUP_SKIP="${WARMUP_SKIP:-0}"
 # cumulative compile time added during the pass's final 120s.
 JIT_SETTLED_RATIO="${JIT_SETTLED_RATIO:-0.02}"
 JIT_TAIL_SAMPLES=8
-# The warm-up pass ends with a large replication backlog, which drains far
-# slower than the initial catch-up (past runs peaked near 450s). Budget more.
-LAG_WAIT_TRIES="${LAG_WAIT_TRIES:-100}"
+# Both waits budget 30 minutes because both start from a backlog a full pass
+# built up. The pre-warm-up wait used to budget 500s on the assumption that an
+# arm starts from an idle replica - true only for the first arm of a session.
+# Every later one starts on what the previous arm's measured pass left behind,
+# which aborted an arm at 523s while the replica reached GTID parity about a
+# minute later. Waiting longer costs wall time; not waiting spends the replica's
+# CPU on backlog instead of reads, which is the larger distortion.
+LAG_WAIT_TRIES="${LAG_WAIT_TRIES:-360}"
 LAG_WAIT_TRIES_POST_WARMUP="${LAG_WAIT_TRIES_POST_WARMUP:-360}"
 SETTLE_SECONDS=20
 


### PR DESCRIPTION
## :sparkles: 이슈 번호: #135 


## :bulb: 상세 내용:
## 문제

run-ab.sh는 A/B 측정 전에 MySQL replica가 primary를 따라잡을 때까지 기다린다.
밀린 상태로 측정하면 replica CPU가 읽기가 아니라 밀린 로그 적용에 쓰여 수치가 왜곡되기 때문이다.

그 대기 예산이 500초였는데, 이 값은 "arm이 따라잡은 replica에서 시작한다"는 전제에
맞춰져 있었다. 그 전제는 한 세션의 첫 arm에서만 참이다. 두 번째 arm부터는 직전 arm의
측정 패스가 남긴 백로그 위에서 시작한다 - run-ab.sh가 측정 패스 뒤에는 lag 0을
기다리지 않기 때문이다.

## 실제 발생

2026-08-16, 6회 스위트의 2번째 arm이 523초에서 중단됐다. 그런데 replica는 정상이었다.

- IO/SQL 스레드 모두 running, 에러 없음, applier 워커 2개 동작
- 중단 약 1분 뒤 GTID 동기화 완료 (남은 트랜잭션 18,500건을 드레인 중이었을 뿐)

헷갈리게 만든 건 Seconds_Behind_Source가 중단 직전까지 오히려 증가했다는 점이다
(619 -> 701). 멀티스레드 replica에서 정상이고, 측정 프로토콜 5번 규칙이
"이 값을 진행 상황으로 읽지 말 것"이라고 못박은 이유다.

즉 스크립트가 건강한 replica를 기다리다 실험을 스스로 죽였다.

## 변경

- LAG_WAIT_TRIES="${LAG_WAIT_TRIES:-100}"     # 500초
+ LAG_WAIT_TRIES="${LAG_WAIT_TRIES:-360}"     # 30분

워밍업 이후 대기(LAG_WAIT_TRIES_POST_WARMUP)는 이미 30분이었고, 이전 대기만
500초로 남아 있었다. 둘 다 "직전 패스가 쌓은 백로그에서 시작한다"는 같은 조건이므로
값을 맞췄다.

트레이드오프는 명확하다 - 더 기다리면 벽시계 시간을 쓰고, 안 기다리면 측정이
왜곡된다. 후자가 더 큰 손해다.

## 범위

docs/load-test/run-ab.sh
docs/load-test/measurement-protocol.md

앱 코드 변경 없음.
