### PR TITLE
세션을 Redis로 이전 — 인스턴스 정지에도 로그인 유지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,11 @@ jib {
 				'-Xms200m',
 				'-Xmx240m',
 				'-XX:ReservedCodeCacheSize=64m',
-				'-XX:MaxMetaspaceSize=128m',
+				// 128m was enough until spring-session-data-redis and its Lettuce
+				// transport arrived: class loading settled at 112m before, and the
+				// first load test after the change died with OutOfMemoryError:
+				// Metaspace at 98% failed requests.
+				'-XX:MaxMetaspaceSize=256m',
 				'-XX:+UseStringDeduplication',
 				'-Dspring.profiles.active=dev',
 				'-Dfile.encoding=UTF-8',
@@ -68,6 +72,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'com.github.ben-manes.caffeine:caffeine'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
     testImplementation 'org.projectlombok:lombok:1.18.28'
     compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,145 @@
 services:
-  mysql:
+  mysql-master:
     image: mysql:8
-    container_name: mysql
+    container_name: popping-mysql-master
     restart: always
+    cpus: 1.0
+    mem_limit: 1024m
+    command:
+      - "--server-id=1"
+      - "--gtid-mode=ON"
+      - "--enforce-gtid-consistency=ON"
+      - "--log-bin=mysql-bin"
+      - "--binlog-format=ROW"
+      - "--performance-schema=ON"
+      - "--slow-query-log=1"
+      - "--long-query-time=1"
+      - "--max-connections=200"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
-      - mysql-data:/var/lib/mysql
-      - ./mysql/my.cnf:/etc/mysql/conf.d/monitoring.cnf:ro
+      - mysql-master-data:/var/lib/mysql
+      - ./mysql/init-master.sql:/docker-entrypoint-initdb.d/init-master.sql:ro
     networks:
       - popping-net
 
-  app:
-    image: chooh1010/popping-community:latest
-    container_name: popping-community
+  mysql-replica:
+    image: mysql:8
+    container_name: popping-mysql-replica
     restart: always
-    depends_on:
-      - mysql
-    ports:
-      - "8080:8080"
-      - "127.0.0.1:8081:8081"
+    cpus: 1.0
+    mem_limit: 1024m
+    command:
+      - "--server-id=2"
+      - "--gtid-mode=ON"
+      - "--enforce-gtid-consistency=ON"
+      - "--performance-schema=ON"
+      - "--slow-query-log=1"
+      - "--long-query-time=1"
+      - "--replica-parallel-workers=2"
+      - "--max-connections=200"
     environment:
-      SERVER_PORT: "8080"
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
-      SPRING_DATASOURCE_USERNAME: root
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:
+      - "3308:3306"
+    volumes:
+      - mysql-replica-data:/var/lib/mysql
+    depends_on:
+      - mysql-master
+    networks:
+      - popping-net
+
+  replica-setup:
+    image: mysql:8
+    container_name: popping-replica-setup
+    depends_on:
+      - mysql-master
+      - mysql-replica
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        echo "Waiting for master..."
+        until mysql -h mysql-master -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "SELECT 1" &>/dev/null; do sleep 2; done
+        echo "Waiting for replica..."
+        until mysql -h mysql-replica -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "SELECT 1" &>/dev/null; do sleep 2; done
+
+        echo "Checking replication health..."
+        IO_RUNNING=$$(mysql -h mysql-replica -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "SHOW REPLICA STATUS\G" 2>/dev/null | grep "Replica_IO_Running:" | awk '{print $$2}')
+        SQL_RUNNING=$$(mysql -h mysql-replica -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "SHOW REPLICA STATUS\G" 2>/dev/null | grep "Replica_SQL_Running:" | head -1 | awk '{print $$2}')
+
+        if [ "$$IO_RUNNING" = "Yes" ] && [ "$$SQL_RUNNING" = "Yes" ]; then
+          echo "Replication is healthy. Nothing to do."
+          exit 0
+        fi
+
+        echo "Replication is broken or not configured (IO=$$IO_RUNNING, SQL=$$SQL_RUNNING). Reconfiguring..."
+        mysql -h mysql-replica -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "STOP REPLICA; RESET REPLICA ALL;"
+
+        mysql -h mysql-replica -uroot -p"$$MYSQL_ROOT_PASSWORD" <<EOF
+        CHANGE REPLICATION SOURCE TO
+          SOURCE_HOST='mysql-master',
+          SOURCE_USER='repl',
+          SOURCE_PASSWORD='replpassword',
+          SOURCE_AUTO_POSITION=1,
+          GET_SOURCE_PUBLIC_KEY=1;
+        START REPLICA;
+        EOF
+
+        sleep 2
+        echo "Setting read-only mode..."
+        mysql -h mysql-replica -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "SET GLOBAL read_only=ON; SET GLOBAL super_read_only=ON;"
+
+        echo "Replication status:"
+        mysql -h mysql-replica -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "SHOW REPLICA STATUS\G" | grep -E "Replica_IO_Running|Replica_SQL_Running|Seconds_Behind"
+        echo "Done."
+    restart: "no"
+    networks:
+      - popping-net
+
+  haproxy:
+    image: haproxy:2.8
+    container_name: popping-haproxy
+    restart: always
+    cpus: 0.5
+    mem_limit: 128m
+    ports:
+      - "9091:9091"
+      - "127.0.0.1:9404:8404"
+    volumes:
+      - ./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+    depends_on:
+      - app-1
+      - app-2
+    networks:
+      - popping-net
+
+  app-1:
+    image: chooh1010/popping-community:redis-session-optin-20260818
+    container_name: popping-app-1
+    restart: always
+    cpus: 2.0
+    mem_limit: 2048m
+    depends_on:
+      - mysql-master
+      - redis
+    ports:
+      - "127.0.0.1:8081:8081"
+    environment: &app-env
+      SERVER_PORT: "9091"
+      APP_DATASOURCE_WRITE_JDBC_URL: jdbc:mysql://mysql-master:3306/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true&useAffectedRows=true
+      APP_DATASOURCE_WRITE_USERNAME: root
+      APP_DATASOURCE_WRITE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      APP_DATASOURCE_WRITE_MAXIMUM_POOL_SIZE: "50"
+      APP_DATASOURCE_READ_JDBC_URL: jdbc:mysql://mysql-replica:3306/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true&useAffectedRows=true
+      APP_DATASOURCE_READ_USERNAME: root
+      APP_DATASOURCE_READ_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      APP_DATASOURCE_READ_MAXIMUM_POOL_SIZE: "80"
       MANAGEMENT_SERVER_PORT: "8081"
       MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: "health,prometheus"
       MANAGEMENT_ENDPOINT_PROMETHEUS_ENABLED: "true"
@@ -47,36 +159,130 @@ services:
             }
           }
         }
-      # Cache is configured by CacheConfig bean (per-cache settings).
-      # SPRING_CACHE_* env vars are ignored when explicit CacheManager exists.
-      SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: 30
+      SPRING_CACHE_TYPE: "caffeine"
+      GUEST_IDENTIFIER_HMAC_SECRET: ${GUEST_IDENTIFIER_HMAC_SECRET}
+      GUEST_IDENTIFIER_SECURE_COOKIE: "false"
       SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT: 30000
       SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.MySQL8Dialect
       SPRING_JPA_OPEN_IN_VIEW: "false"
       SPRING_JPA_SHOW_SQL: "false"
       SPRING_JPA_HIBERNATE_FORMAT_SQL: "false"
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
-      CLOUD_AWS_CREDENTIALS_ACCESSKEY: ${CLOUD_AWS_CREDENTIALS_ACCESSKEY}
-      CLOUD_AWS_CREDENTIALS_SECRETKEY: ${CLOUD_AWS_CREDENTIALS_SECRETKEY}
-      CLOUD_AWS_S3_BUCKETNAME: ${CLOUD_AWS_S3_BUCKETNAME}
-      CLOUD_AWS_REGION_STATIC: ${CLOUD_AWS_REGION_STATIC}
+      CLOUD_AWS_CREDENTIALS_ACCESSKEY: dummy
+      CLOUD_AWS_CREDENTIALS_SECRETKEY: dummy
+      CLOUD_AWS_S3_BUCKETNAME: dummy
+      CLOUD_AWS_REGION_STATIC: ap-northeast-2
       CLOUD_AWS_STACK_AUTO: "false"
+      APP_STICKY_PRIMARY_ENABLED: "true"
+      # Sessions live in Redis so an instance dying does not take its users'
+      # sessions with it. This is the opt-in RedisSessionConfig waits for; without
+      # it sessions stay in Tomcat's memory, which is what an environment with no
+      # Redis needs. Boot's own spring.session.store-type cannot do this - it was
+      # removed in Boot 3.x and is silently ignored.
+      APP_SESSION_STORE: "redis"
+      SPRING_DATA_REDIS_HOST: "redis"
+      SPRING_DATA_REDIS_PORT: "6379"
+      # JAVA_TOOL_OPTIONS does NOT set the heap here, whatever it looks like.
+      # jib bakes -Xms200m -Xmx240m -XX:MaxMetaspaceSize=256m into the image as
+      # command-line arguments (build.gradle jvmFlags), and command-line arguments
+      # win over this variable - the JVM logs "Picked up JAVA_TOOL_OPTIONS" and
+      # then ignores the conflicting flags. Verified 2026-08-17: G1 Old Gen max
+      # reported 240MB while this line claimed 1024m, so every load test so far
+      # has run on a 240MB heap.
+      #
+      # It is left in place because the non-conflicting flags do apply, and
+      # because removing it would quietly change what past runs were compared
+      # against. To actually change a JVM flag for this rig, override it at build
+      # time instead:
+      #   ./gradlew jibDockerBuild -Djib.container.jvmFlags=<comma,separated>
+      # MaxMetaspaceSize was first raised to 256m that way, when the Redis client
+      # pushed class loading to 112MB against the image's 128m cap and a load pass
+      # died with OutOfMemoryError: Metaspace and 98% timeouts while the container
+      # sat at 626MB of its 2GB. build.gradle now carries the 256m itself, so a
+      # plain rebuild no longer regresses to the cap that failed.
+      JAVA_TOOL_OPTIONS: "-Xms1024m -Xmx1024m -XX:+AlwaysPreTouch"
     networks:
       - popping-net
 
-  node-exporter:
-    image: prom/node-exporter:latest
-    container_name: node-exporter
+  app-2:
+    image: chooh1010/popping-community:redis-session-optin-20260818
+    container_name: popping-app-2
     restart: always
+    cpus: 2.0
+    mem_limit: 2048m
+    depends_on:
+      - mysql-master
+      - redis
     ports:
-      - "127.0.0.1:9100:9100"
+      - "127.0.0.1:8082:8081"
+    environment:
+      <<: *app-env
+    networks:
+      - popping-net
+
+  redis:
+    image: redis:7.4-alpine
+    container_name: popping-redis
+    restart: always
+    cpus: 0.5
+    mem_limit: 256m
+    # noeviction, not allkeys-lru: this instance holds sessions, and evicting a
+    # session under memory pressure logs a user out silently. maxmemory is set
+    # below mem_limit so Redis refuses writes before the container is OOM-killed.
+    command:
+      - "redis-server"
+      - "--maxmemory"
+      - "192mb"
+      - "--maxmemory-policy"
+      - "noeviction"
+      - "--save"
+      - ""
+      - "--appendonly"
+      - "no"
+    # Deliberately not published to the host. The apps reach it over the compose
+    # network, so a host port would only be for inspection - and something else
+    # already holds 6379 on this machine. Use `docker exec popping-redis
+    # redis-cli` instead.
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    networks:
+      - popping-net
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: popping-cadvisor-local
+    restart: always
+    cpus: 0.1
+    mem_limit: 64m
+    ports:
+      - "127.0.0.1:8084:8080"
+    volumes:
+      - //var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - popping-net
+
+  docker-stats-exporter:
+    image: wywywywy/docker_stats_exporter:latest
+    container_name: popping-docker-stats-exporter
+    restart: always
+    cpus: 0.05
+    mem_limit: 32m
+    ports:
+      - "127.0.0.1:9487:9487"
+    volumes:
+      - //var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - popping-net
 
   mysqld-exporter:
     image: prom/mysqld-exporter:v0.15.1
-    container_name: mysqld-exporter
+    container_name: popping-mysqld-exporter-local
     restart: always
+    cpus: 0.1
+    mem_limit: 64m
     volumes:
       - ./mysql/mysqld-exporter.my.cnf:/.my.cnf:ro
     command:
@@ -92,12 +298,39 @@ services:
     ports:
       - "127.0.0.1:9104:9104"
     depends_on:
-      - mysql
+      - mysql-master
+    networks:
+      - popping-net
+
+  mysqld-exporter-replica:
+    image: prom/mysqld-exporter:v0.16.0
+    container_name: popping-mysqld-exporter-replica
+    restart: always
+    cpus: 0.1
+    mem_limit: 64m
+    volumes:
+      - ./mysql/mysqld-exporter-replica.my.cnf:/.my.cnf:ro
+    command:
+      - "--config.my-cnf=/.my.cnf"
+      - "--collect.global_status"
+      - "--collect.global_variables"
+      - "--collect.info_schema.innodb_metrics"
+      - "--collect.perf_schema.eventsstatements"
+      - "--collect.perf_schema.eventsstatementssum"
+      - "--collect.perf_schema.tablelocks"
+      - "--collect.perf_schema.tableiowaits"
+      - "--collect.info_schema.processlist"
+      - "--collect.slave_status"
+    ports:
+      - "127.0.0.1:9105:9104"
+    depends_on:
+      - mysql-replica
     networks:
       - popping-net
 
 volumes:
-  mysql-data:
+  mysql-master-data:
+  mysql-replica-data:
 
 networks:
   popping-net:

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -1,0 +1,29 @@
+global
+    log stdout format raw local0 info
+
+defaults
+    log     global
+    mode    http
+    option  httplog
+    option  forwardfor
+    timeout connect 5s
+    timeout client  60s
+    timeout server  60s
+
+frontend http_front
+    bind *:9091
+    default_backend app_servers
+
+backend app_servers
+    # No sticky cookie: sessions are in Redis, so any instance can serve any
+    # request. Pinning a user to one instance is what made losing that instance
+    # log them out, and it also hid the cache and broker state being per-process.
+    balance roundrobin
+    server app1 popping-app-1:9091 check
+    server app2 popping-app-2:9091 check
+
+frontend stats
+    bind *:8404
+    stats enable
+    stats uri /stats
+    stats refresh 10s

--- a/src/main/java/com/example/popping/config/app/RedisSessionConfig.java
+++ b/src/main/java/com/example/popping/config/app/RedisSessionConfig.java
@@ -1,0 +1,65 @@
+package com.example.popping.config.app;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+
+import jakarta.servlet.DispatcherType;
+
+/**
+ * Stores HTTP sessions in Redis, but only where an environment asks for it.
+ *
+ * <p>Spring Boot decides the session store from the classpath alone: with
+ * spring-session-data-redis on it, every environment switches to Redis and there is no
+ * property to opt out - {@code spring.session.store-type} was removed in Boot 3.x, so
+ * setting it to {@code none} does nothing. Running without a Redis to talk to therefore
+ * starts the app fine and then fails every request that touches a session with a 500,
+ * which is what {@code ./gradlew bootRun} does on a machine with no Redis.
+ *
+ * <p>{@code SessionAutoConfiguration} is excluded in application.yml so that decision is
+ * ours to make, and this class makes it: sessions live in Redis when
+ * {@code app.session.store=redis}, and stay in Tomcat's memory otherwise.
+ *
+ * <p>{@code @EnableRedisHttpSession} is the non-indexed repository, matching what the
+ * auto-configuration used before this class existed - one key per session under
+ * {@code spring:session:sessions:}, no expiration index. It publishes no expiration
+ * events and has no {@code findByPrincipalName}; needing either means moving to
+ * {@code @EnableRedisIndexedHttpSession}, which changes the key layout and wants Redis
+ * keyspace notifications.
+ *
+ * <p>What the exclusion costs: the {@code spring.session.*} properties no longer reach
+ * the repository, so session timeout is the annotation's own 30-minute default rather
+ * than {@code server.servlet.session.timeout}. That property still binds and still
+ * governs Tomcat, so setting it later would move Tomcat's timeout while leaving Redis at
+ * 30 minutes. Both are 30 minutes today, which is why this is a note and not a change.
+ */
+@Configuration
+@ConditionalOnProperty(name = "app.session.store", havingValue = "redis")
+@EnableRedisHttpSession
+public class RedisSessionConfig {
+
+    /**
+     * Registers the session filter for the same dispatcher types Boot used to register it
+     * for.
+     *
+     * <p>Left to Boot's ordinary filter-bean registration, {@code SessionRepositoryFilter}
+     * would run on {@code REQUEST} only, while {@code SessionAutoConfiguration} registered
+     * it for {@code REQUEST}, {@code ASYNC} and {@code ERROR}. On the dispatches it no
+     * longer covers, {@code request.getSession()} falls through to Tomcat's own session
+     * instead of the one in Redis - and SockJS transports dispatch asynchronously, so
+     * {@code ASYNC} is not hypothetical here.
+     */
+    @Bean
+    FilterRegistrationBean<SessionRepositoryFilter<?>> sessionRepositoryFilterRegistration(
+            SessionRepositoryFilter<?> sessionRepositoryFilter) {
+        FilterRegistrationBean<SessionRepositoryFilter<?>> registration =
+                new FilterRegistrationBean<>(sessionRepositoryFilter);
+        registration.setDispatcherTypes(
+                DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR);
+        registration.setOrder(SessionRepositoryFilter.DEFAULT_ORDER);
+        return registration;
+    }
+}

--- a/src/main/java/com/example/popping/domain/UserPrincipal.java
+++ b/src/main/java/com/example/popping/domain/UserPrincipal.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class UserPrincipal implements UserDetails, Serializable {
+public class UserPrincipal implements UserDetails, CredentialsContainer, Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
@@ -44,6 +45,18 @@ public class UserPrincipal implements UserDetails, Serializable {
     @Override
     public String getPassword() {
         return passwordHash;
+    }
+
+    /**
+     * Spring Security calls this once authentication succeeds, so the hash lives only
+     * as long as the password check needs it. Without this it rides along in the
+     * session - and the session is now in Redis, which would put every logged-in
+     * user's BCrypt hash in a second store that has no reason to hold credentials.
+     * Nothing reads {@link #getPassword()} after authentication.
+     */
+    @Override
+    public void eraseCredentials() {
+        this.passwordHash = null;
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+# Defaults that must exist in every environment.
+#
+# application.properties holds the environment-specific settings and is not
+# committed (it carries credentials, and CI injects it from a secret). Anything
+# that has to be true everywhere therefore cannot live there, so it lives here.
+# Spring Boot loads both from this location and application.properties wins on
+# conflict, so nothing set there is overridden by this file.
+spring:
+  autoconfigure:
+    exclude:
+      # Boot picks the session store from the classpath: spring-session-data-redis
+      # being present is enough to move every environment's sessions to Redis, and
+      # spring.session.store-type - the property that used to turn that off - was
+      # removed in Boot 3.x. Excluding the auto-configuration hands the decision to
+      # RedisSessionConfig, which only switches when app.session.store=redis.
+      - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration

--- a/src/test/java/com/example/popping/config/app/RedisSessionConfigTest.java
+++ b/src/test/java/com/example/popping/config/app/RedisSessionConfigTest.java
@@ -1,0 +1,99 @@
+package com.example.popping.config.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.data.redis.RedisSessionRepository;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+
+import jakarta.servlet.DispatcherType;
+
+/**
+ * Guards the opt-in that keeps sessions out of Redis unless an environment asks for it.
+ *
+ * <p>The configuration this replaced used spring.session.store-type, which Boot 3.x
+ * removed - it was ignored in both directions, so sessions went to Redis everywhere. A
+ * test that only checked the opt-in case would have passed against that broken config
+ * too, which is why the default case asserts a SessionRepository is absent rather than
+ * asserting anything about the store that is present.
+ */
+class RedisSessionConfigTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class))
+            .withUserConfiguration(RedisSessionConfig.class);
+
+    @Test
+    @DisplayName("app.session.store=redis 이면 Redis 세션 저장소가 등록된다")
+    void redisStore_registersRedisSessionRepository() {
+        runner.withPropertyValues("app.session.store=redis")
+                .run(context -> assertThat(context).hasSingleBean(RedisSessionRepository.class));
+    }
+
+    @Test
+    @DisplayName("app.session.store 가 없으면 세션 저장소를 전혀 등록하지 않는다")
+    void noProperty_registersNoSessionRepository() {
+        runner.run(context -> assertThat(context).doesNotHaveBean(SessionRepository.class));
+    }
+
+    @Test
+    @DisplayName("app.session.store 가 redis 가 아니면 세션 저장소를 등록하지 않는다")
+    void otherStore_registersNoSessionRepository() {
+        runner.withPropertyValues("app.session.store=none")
+                .run(context -> assertThat(context).doesNotHaveBean(SessionRepository.class));
+    }
+
+    @Test
+    @DisplayName("Redis 세션 필터는 REQUEST/ASYNC/ERROR 모두에서 동작한다")
+    void filterRegistration_coversAsyncAndErrorDispatches() {
+        // Left to Boot's plain filter-bean registration this would be REQUEST only, and
+        // the dispatches it missed would silently fall back to Tomcat's session. SockJS
+        // transports dispatch asynchronously, so ASYNC is a live path here.
+        runner.withPropertyValues("app.session.store=redis").run(context -> {
+            FilterRegistrationBean<?> registration =
+                    context.getBean(FilterRegistrationBean.class);
+            assertThat(registration.getOrder()).isEqualTo(SessionRepositoryFilter.DEFAULT_ORDER);
+            assertThat(registration).extracting("dispatcherTypes")
+                    .asInstanceOf(InstanceOfAssertFactories.iterable(DispatcherType.class))
+                    .containsExactlyInAnyOrder(
+                            DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR);
+        });
+    }
+
+    @Test
+    @DisplayName("application.yml 이 SessionAutoConfiguration 배제를 실제로 환경에 싣는다")
+    void applicationYml_carriesTheExclusion() {
+        // The three tests above never load application.yml, so they would all still pass
+        // if the exclusion were deleted - and then the auto-configuration below would take
+        // over and put every environment back on Redis. This is what ties them together.
+        new ApplicationContextRunner()
+                .withInitializer(new ConfigDataApplicationContextInitializer())
+                .withPropertyValues("spring.config.location=classpath:/application.yml")
+                .run(context -> assertThat(context.getEnvironment()
+                        .getProperty("spring.autoconfigure.exclude[0]"))
+                        .isEqualTo(SessionAutoConfiguration.class.getName()));
+    }
+
+    @Test
+    @DisplayName("SessionAutoConfiguration 이 살아 있으면 opt-in 없이도 Redis 세션이 켜진다")
+    void autoConfigurationAlone_switchesToRedisWithoutOptIn() {
+        // The reason application.yml excludes it. If this ever stops holding, the
+        // exclusion is no longer load-bearing and the comment there is wrong. The
+        // auto-configuration only applies to servlet web applications, hence the
+        // web runner rather than the plain one used above.
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        RedisAutoConfiguration.class, SessionAutoConfiguration.class))
+                .run(context -> assertThat(context).hasSingleBean(SessionRepository.class));
+    }
+}

--- a/src/test/java/com/example/popping/domain/UserPrincipalTest.java
+++ b/src/test/java/com/example/popping/domain/UserPrincipalTest.java
@@ -1,0 +1,72 @@
+package com.example.popping.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The principal ends up in the session, and the session now lives in Redis. Anything
+ * still attached to it is written to that store on every login, so the password hash
+ * has to be gone by then.
+ */
+class UserPrincipalTest {
+
+    private UserPrincipal principal() {
+        return UserPrincipal.builder()
+                .userId(1L)
+                .loginId("user86")
+                .nickname("tester")
+                .passwordHash("$2b$10$kOwRIUPIxcFA72eznzcqdOHfakehashvalueforatest")
+                .role(UserRole.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("인증 전에는 비밀번호 해시를 제공한다")
+    void password_availableBeforeErasure() {
+        assertThat(principal().getPassword()).startsWith("$2b$");
+    }
+
+    @Test
+    @DisplayName("eraseCredentials 이후에는 비밀번호 해시가 남지 않는다")
+    void password_clearedAfterErasure() {
+        UserPrincipal user = principal();
+
+        user.eraseCredentials();
+
+        assertThat(user.getPassword()).isNull();
+        assertThat(user.getPasswordHash()).isNull();
+    }
+
+    @Test
+    @DisplayName("인증 토큰을 지우면 principal의 해시까지 함께 지워진다")
+    void tokenErasure_cascadesToPrincipal() {
+        UserPrincipal user = principal();
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                user, "raw-password", user.getAuthorities());
+
+        // Spring Security의 ProviderManager가 인증 성공 후 호출하는 경로다.
+        ((UsernamePasswordAuthenticationToken) auth).eraseCredentials();
+
+        assertThat(auth.getCredentials()).isNull();
+        assertThat(((UserPrincipal) auth.getPrincipal()).getPassword()).isNull();
+    }
+
+    @Test
+    @DisplayName("해시를 지워도 인가에 필요한 정보는 그대로 남는다")
+    void erasure_keepsAuthorizationData() {
+        UserPrincipal user = principal();
+
+        user.eraseCredentials();
+
+        assertThat(user.getUserId()).isEqualTo(1L);
+        assertThat(user.getUsername()).isEqualTo("user86");
+        assertThat(user.getNickname()).isEqualTo("tester");
+        assertThat(user.getAuthorities())
+                .extracting("authority")
+                .containsExactly(UserRole.USER.name());
+    }
+}


### PR DESCRIPTION
## :sparkles: 이슈 번호: #137 


## :bulb: 상세 내용:
## 요약

Tomcat 인메모리 세션을 Redis로 옮기고, HAProxy sticky 쿠키를 제거했다.
커밋 2개다.

- 48fe06c  세션에 실리던 BCrypt 해시 소거
- e96cd07  세션 Redis 이전 (환경별 opt-in)

## 1. 문제 재현

로그인한 뒤 그 세션이 올라간 인스턴스를 정지하고 같은 쿠키로 재요청했다.
내릴 컨테이너는 SERVERID 쿠키를 읽어 정했다 — 하드코딩하면 엉뚱한 쪽을 내려
200 OK가 나오고, 그건 "문제 없음"이 아니라 "실험 실패"인데 겉보기가 같다.

  before  302 -> /login
  after   200 OK   (1대 정지 상태로 10회 연속)

## 2. 안전 기본값이 작동하지 않았다

처음엔 커밋되는 application.yml에 spring.session.store-type: none 을 두고
환경변수로 opt-in 하게 했다. 코드 리뷰 지적을 받고 검증해보니 아무 일도
하지 않는 설정이었다.

| application.yml   | 환경변수 | 결과                    |
|-------------------|---------|-------------------------|
| store-type: none  | =redis  | SESSION 쿠키 + Redis 키 1 |
| store-type: none  | 없음     | SESSION 쿠키 + Redis 키 1 |
| 줄 자체 없음        | 없음     | SESSION 쿠키 + Redis 키 1 |

셋이 같다. spring.session.store-type 은 Boot 3.x에서 제거된 속성이라
none 도 =redis 도 무시되고, 세션 저장소는 클래스패스만으로 결정된다.
Boot 3.4.3의 설정 메타데이터에 이 속성이 아예 없다.

막으려던 고장을 실제로 일으켜봤다. Redis를 내리고 로그인하면:

  HTTP/1.1 500
  RedisConnectionFailureException: Unable to connect to Redis

안전장치를 넣은 상태에서 그대로 났다.

## 3. 다시 만든 방법

끄는 속성이 없으므로 결정 자체를 가져왔다.

application.yml 에서 SessionAutoConfiguration 을 배제하고,
RedisSessionConfig 가 app.session.store=redis 일 때만 켠다.

같은 세 경우를 다시 돌렸다.

| opt-in | Redis  | 결과                      |
|--------|--------|---------------------------|
| 있음    | 있음    | SESSION 쿠키 + Redis 키 1  |
| 없음    | 있음    | JSESSIONID, Redis 키 0     |
| 없음    | 내림    | 로그인 302 정상             |

세 번째 줄이 이 수정의 목적이다. 500이던 자리가 302가 됐다.

@EnableRedisHttpSession 은 non-indexed 저장소로, 자동 설정이 쓰던 것과
키 구조가 같다(spring:session:sessions:<id>). 저장소를 바꾸지 않는 것이
이번 변경의 의도다.

다만 이 저장소에는 findByPrincipalName 이 없다. 나중에 계정 정지나
강제 로그아웃을 만들 때는 @EnableRedisIndexedHttpSession 으로 바꿔야 한다.

## 4. 세션 필터 dispatcher types

SessionRepositoryFilter 를 그냥 빈으로 두면 Boot가 REQUEST 에만 등록한다.
원래 SessionAutoConfiguration 은 REQUEST/ASYNC/ERROR 셋 다 등록하고 있었다.

빠진 dispatch에서는 request.getSession() 이 Redis가 아니라 Tomcat 세션으로
떨어진다. 이 앱은 SockJS가 async 서블릿을 쓰므로 ASYNC는 실제 경로다.
FilterRegistrationBean 으로 Boot와 동일하게 등록했다.

(이 항목은 Boot 소스의 등록 방식과 대조로 확인했고, 에러 페이지가 세션을
쓰지 않아 실측 재현은 하지 못했다.)

## 5. 자격증명 소거 (별도 커밋)

세션을 열어보니 BCrypt 해시가 실려 있었다. DB 행의 해시 조각과 대조해 확인했다.
UserPrincipal 이 CredentialsContainer 를 구현하게 해서 인증 직후 소거한다
(ProviderManager 가 기본으로 호출한다).

인증 이후 getPassword() 를 읽는 곳은 없다 — remember-me 없고, 재인증 경로
없고, STOMP 인터셉터는 id와 권한만 본다.

  세션 내 해시 검출  1건 -> 0건
  세션 크기          2,884B -> 2,813B

## 6. Redis 설정

  --maxmemory 192mb --maxmemory-policy noeviction

세션 저장소에서 축출은 "사용자가 이유 없이 로그아웃되는" 장애다.
컨테이너 한도(256MB)보다 낮게 잡아 OOM kill 전에 쓰기를 거부하게 했다.

## 7. Metaspace

Redis 클라이언트가 들어오면서 클래스 로딩이 늘어 이미지에 박힌 128m를 넘겼고,
부하 중 OutOfMemoryError: Metaspace 로 요청 98%가 실패했다. 기동 직후 측정이
111.9MB / 128MB 였다.

build.gradle 에서 256m으로 올렸다. 빌드 시점 오버라이드로만 두면 다시 빌드할 때
회귀하기 때문이다. 현재 실측은 119.1MB / 256MB.

## 8. 검증 (750 VUser 1패스)

  에러                0%          (235,103 샘플)
  Redis 명령          초당 550건
  Redis 메모리        1.1 -> 1.7MB / 192MB
  세션 수             233개       (로그인 스레드 수와 일치)
  HAProxy 분산        118,094 / 118,094  (정확히 50.0%)

6회 A/B는 의도적으로 생략했다. 인증 요청당 HGETALL 1회가 0.004ms, 왕복 0.2ms대,
인증 비중 31%로 기대 효과가 0.02% 수준이라 이 부하 모델의 검출 한계(약 4%)의
1/200이다. 산술로 결론이 나므로 용량/분산/에러만 1패스로 확인했다.

## 테스트

RedisSessionConfigTest 6개. 뮤테이션으로 검증했다 —
application.yml 의 exclude를 지우면 yml 계약 테스트만,
FilterRegistrationBean 을 지우면 dispatcher 테스트만 정확히 실패한다.

"프로퍼티가 없으면 저장소가 아예 없다"를 단언하는 테스트가 핵심이다.
깨진 설정에서는 여기서 Redis 저장소가 생겨 반드시 실패한다.

## 범위

  build.gradle                        의존성 2개, Metaspace 256m
  src/main/resources/application.yml  신규 - 자동설정 배제
  config/app/RedisSessionConfig.java  신규
  domain/UserPrincipal.java           CredentialsContainer
  docker-compose.yml                  redis 서비스, opt-in 환경변수
  haproxy/haproxy.cfg                 sticky 쿠키 제거
  + 테스트 2개 파일

mysql/ 은 평문 비밀번호가 들어 있어 이번 PR에 넣지 않았다. 별도로 정리한다.

## 비목표

- Redis HA (새 단일 장애점이 생기는 것은 인지하고 받아들였다)
- 캐시 무효화 Pub/Sub, WebSocket 브로드캐스트 복제
- 공유 캐시(L2)
